### PR TITLE
Use <blockquote> for list-free indents

### DIFF
--- a/lib/parse-html.js
+++ b/lib/parse-html.js
@@ -187,6 +187,11 @@ firepad.ParseHtml = (function () {
           case 'br':
             output.newline(state);
             break;
+          case 'blockquote':
+            output.newlineIfNonEmpty(state);
+            parseChildren(node, state.withIncreasedIndent(), output);
+            output.newlineIfNonEmpty(state);
+            break;
           case 'ul':
             output.newlineIfNonEmptyOrListItem(state);
             var listType = node.getAttribute('class') === 'firepad-todo' ? LIST_TYPE.TODO : LIST_TYPE.UNORDERED;

--- a/lib/serialize-html.js
+++ b/lib/serialize-html.js
@@ -12,13 +12,43 @@ firepad.SerializeHtml = (function () {
   var TODO_STYLE = '<style>ul.firepad-todo { list-style: none; margin-left: 0; padding-left: 0; } ul.firepad-todo > li { padding-left: 1em; text-indent: -1em; } ul.firepad-todo > li:before { content: "\\2610"; padding-right: 5px; } ul.firepad-todo > li.firepad-checked:before { content: "\\2611"; padding-right: 5px; }</style>\n';
 
   function open(listType) {
-    return (listType === LIST_TYPE.ORDERED) ? '<ol>' :
-           (listType === LIST_TYPE.UNORDERED) ? '<ul>' :
-           '<ul class="firepad-todo">';
+    switch (listType) {
+      case LIST_TYPE.ORDERED:
+        return '<ol>';
+        break;
+      case LIST_TYPE.UNORDERED:
+        return '<ul>';
+        break;
+      case LIST_TYPE.TODO:
+      case LIST_TYPE.TODOCHECKED:
+        return '<ul class="firepad-todo">';
+        break;
+      case LIST_TYPE.NONE:
+        return '<blockquote>';
+        break;
+      default:
+        throw new Error('unknown list type "' + listType + '"');
+        break;
+    }
   }
 
   function close(listType) {
-    return (listType === LIST_TYPE.ORDERED) ? '</ol>' : '</ul>';
+    switch (listType) {
+      case LIST_TYPE.ORDERED:
+        return '</ol>';
+        break;
+      case LIST_TYPE.UNORDERED:
+      case LIST_TYPE.TODO:
+      case LIST_TYPE.TODOCHECKED:
+        return '</ul>';
+        break;
+      case LIST_TYPE.NONE:
+        return '</blockquote>';
+        break;
+      default:
+        throw new Error('unknown list type "' + listType + '"');
+        break;
+    }
   }
 
   function compatibleListType(l1, l2) {
@@ -82,7 +112,7 @@ firepad.SerializeHtml = (function () {
 
         // Open any needed lists.
         while (listTypeStack.length < indent) {
-          var toOpen = listType || LIST_TYPE.UNORDERED; // default to unordered lists for indenting non-list-item lines.
+          var toOpen = listType || LIST_TYPE.NONE;
           usesTodo = listType == LIST_TYPE.TODO || listType == LIST_TYPE.TODOCHECKED || usesTodo;
           html += open(toOpen);
           listTypeStack.push(toOpen);

--- a/test/specs/integration.spec.js
+++ b/test/specs/integration.spec.js
@@ -94,7 +94,7 @@ describe('Integration tests', function() {
 
     waitsFor(function() { return firepad.ready_ }, 'firepad is ready');
 
-    var html = '<b>bold</b>';
+    var html = '<blockquote><div><b>bold</b></div></blockquote>';
     runs(function() {
       firepad.setHtml(html);
       expect(firepad.getHtml()).toContain(html);
@@ -180,6 +180,7 @@ describe('Integration tests', function() {
       '<br/>' +
       '<div style="font-size: 18px">' +
       'Supports:<br/>' +
+      '<blockquote>' +
       '<ul>' +
         '<li>Different ' +
           '<span style="font-family: impact">fonts,</span>' +
@@ -201,6 +202,7 @@ describe('Integration tests', function() {
         '<li>Cursor / selection synchronization.</li>' +
         '<li>And it\'s all fully collaborative!</li>' +
       '</ul>' +
+      '</blockquote>' +
       '</div>'
 
     var headlessHtml = null;

--- a/test/specs/parse-html.spec.js
+++ b/test/specs/parse-html.spec.js
@@ -111,7 +111,7 @@ describe('Parse HTML Tests', function() {
 
   it('Ordered list', function() {
     var t = Text('Foo', tf);
-    parseTest('<ol><li>Foo</li><li>Foo</li></ul>', [
+    parseTest('<ol><li>Foo</li><li>Foo</li></ol>', [
       Line([t], lf.indent(1).listItem(LIST_TYPE.ORDERED)),
       Line([t], lf.indent(1).listItem(LIST_TYPE.ORDERED))
     ]);
@@ -119,7 +119,7 @@ describe('Parse HTML Tests', function() {
 
   it('Divs listed in list items', function() {
     var t = Text('Foo', tf);
-    parseTest('<ol><li><div>Foo</div><div>Foo</div></li><li>Foo</li></ul>', [
+    parseTest('<ol><li><div>Foo</div><div>Foo</div></li><li>Foo</li></ol>', [
       Line([t], lf.indent(1).listItem(LIST_TYPE.ORDERED)),
       Line([t], lf.indent(1)), // should be indented, but no list item.
       Line([t], lf.indent(1).listItem(LIST_TYPE.ORDERED))

--- a/test/specs/parse-html.spec.js
+++ b/test/specs/parse-html.spec.js
@@ -101,6 +101,18 @@ describe('Parse HTML Tests', function() {
     ]);
   });
 
+  it('Blockquotes', function() {
+    var t = Text('Foo', tf);
+    parseTest('Foo<blockquote><p>Foo</p></blockquote>Foo<blockquote><blockquote><p>Foo</p></blockquote><div>Foo</div></blockquote>Foo', [
+      Line([t], lf),
+      Line([t], lf.indent(1)),
+      Line([t], lf),
+      Line([t], lf.indent(2)),
+      Line([t], lf.indent(1)),
+      Line([t], lf),
+    ]);
+  });
+
   it('Unordered list', function() {
     var t = Text('Foo', tf);
     parseTest('<ul><li>Foo</li><li>Foo</li></ul>', [
@@ -128,22 +140,22 @@ describe('Parse HTML Tests', function() {
 
   it('Complex list (1)', function() {
     var t = Text('Foo', tf);
-    parseTest('<ol><li>Foo<ol><li>Foo</li><li>Foo</li></ol></li><li>Foo</li></ol>', [
-      Line([t], lf.indent(1).listItem(LIST_TYPE.ORDERED)),
-      Line([t], lf.indent(2).listItem(LIST_TYPE.ORDERED)),
-      Line([t], lf.indent(2).listItem(LIST_TYPE.ORDERED)),
-      Line([t], lf.indent(1).listItem(LIST_TYPE.ORDERED))
+    parseTest('<blockquote><blockquote><ol><li>Foo<ol><li>Foo</li><li>Foo</li></ol></li><li>Foo</li></ol></blockquote></blockquote>', [
+      Line([t], lf.indent(3).listItem(LIST_TYPE.ORDERED)),
+      Line([t], lf.indent(4).listItem(LIST_TYPE.ORDERED)),
+      Line([t], lf.indent(4).listItem(LIST_TYPE.ORDERED)),
+      Line([t], lf.indent(3).listItem(LIST_TYPE.ORDERED))
     ]);
   });
 
   // same as last, but with no text on each line.
   it('Complex list (2)', function() {
     var t = Text('Foo', tf);
-    parseTest('<ol><li><ol><li></li><li></li></ol></li><li></li></ol>', [
-      Line([], lf.indent(1).listItem(LIST_TYPE.ORDERED)),
-      Line([], lf.indent(2).listItem(LIST_TYPE.ORDERED)),
-      Line([], lf.indent(2).listItem(LIST_TYPE.ORDERED)),
-      Line([], lf.indent(1).listItem(LIST_TYPE.ORDERED))
+    parseTest('<blockquote><blockquote><ol><li><ol><li></li><li></li></ol></li><li></li></ol></blockquote></blockquote>', [
+      Line([], lf.indent(3).listItem(LIST_TYPE.ORDERED)),
+      Line([], lf.indent(4).listItem(LIST_TYPE.ORDERED)),
+      Line([], lf.indent(4).listItem(LIST_TYPE.ORDERED)),
+      Line([], lf.indent(3).listItem(LIST_TYPE.ORDERED))
     ]);
   });
 


### PR DESCRIPTION
This adds parsing and serialization of `<blockquote>` elements for indented lines that aren’t `<ul>` or `<ol>`.

The previous behaviour was serializing `<ul>` elements with non-`<li>` children, which isn’t really good HTML.
