### PR TITLE
update current attributes 

### DIFF
--- a/lib/firepad.css
+++ b/lib/firepad.css
@@ -143,6 +143,12 @@ a.firepad-btn:active {
   box-shadow: inset 0 2px 4px rgba(0,0,0,0.15),0 1px 2px rgba(0,0,0,0.05);
 }
 
+a.firepad-btn-highlight {
+	color: #fff;
+	background-color: #ffbf86;
+	border-color: #e6a165;
+}
+
 .firepad-btn-group > .firepad-btn {
   -webkit-border-radius: 0;
   -moz-border-radius: 0;

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -935,12 +935,16 @@ firepad.RichTextCodeMirror = (function () {
       if (nextc=='\n') pos++; // we're just before a newline, advance to the newline
     }
 
-    var spans = this.annotationList_.getAnnotatedSpansForPos(pos);
-    
-    // special case for head==0 or beginning of a non empty line (and not selection), look right if possible
-    var lookLeft=true;
+    var spans, lookLeft;
     var nextc=this.getRange(head, head+1), eol=(nextc=='\n' || nextc==''), sol=(this.getRange(head-1, head)==LineSentinelCharacter);
-    if (anchor==head && (head==0 || (sol && !eol))) lookLeft=(spans.length===1); 
+    if (anchor==head && (head==0 || (sol && !eol))) {
+      // special case for head==0 or beginning of a non empty line (and not selection), look right if possible
+      spans = this.annotationList_.getAnnotatedSpansForPos(head);
+      lookLeft=(spans.length===1); 
+    } else {
+      lookLeft=true;
+      spans = this.annotationList_.getAnnotatedSpansForPos(pos);
+    }
     
     this.currentAttributes_ = {};
     var attributes = {};

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -991,8 +991,8 @@ firepad.RichTextCodeMirror = (function () {
 
   // If newState is provided add/remove theClass accordingly, otherwise toggle theClass
   function toggleClass(elem, theClass, newState) {
-    let matchRegExp = new RegExp('(?:^|\\s)' + theClass + '(?!\\S)', 'g');
-    let add = (arguments.length > 2 ? newState : (elem.className.match(matchRegExp) === null));
+    var matchRegExp = new RegExp('(?:^|\\s)' + theClass + '(?!\\S)', 'g');
+    var add = (arguments.length > 2 ? newState : (elem.className.match(matchRegExp) === null));
 
     elem.className = elem.className.replace(matchRegExp, ''); // clear all
     if (add) elem.className += ' ' + theClass;

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -1060,6 +1060,7 @@ firepad.RichTextCodeMirror = (function () {
   RichTextCodeMirror.prototype.deleteLeft = function() {
     var cm = this.codeMirror;
     var cursorPos = cm.getCursor('head');
+    if (cm.indexFromPos(cursorPos)===0) return; // nothing to delete
     var lineAttributes = this.getLineAttributes_(cursorPos.line);
     var listType = lineAttributes[ATTR.LIST_TYPE];
     var indent = lineAttributes[ATTR.LINE_INDENT];

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -903,47 +903,49 @@ firepad.RichTextCodeMirror = (function () {
     return this.currentAttributes_;
   };
 
-  RichTextCodeMirror.prototype.updateCurrentAttributes_ = function() {
-    var cm = this.codeMirror;
-    var anchor = cm.indexFromPos(cm.getCursor('anchor')), head = cm.indexFromPos(cm.getCursor('head'));
-    var pos = head;
-    if (anchor > head) { // backwards selection
-      // Advance past any newlines or line sentinels.
-      while(pos < this.end()) {
-        var c = this.getRange(pos, pos+1);
-        if (c !== '\n' && c !== LineSentinelCharacter)
-          break;
-        pos++;
-      }
-      if (pos < this.end())
-        pos++; // since we're going to look at the annotation span to the left to decide what attributes to use.
-    } else {
-      // Back up before any newlines or line sentinels.
-      while(pos > 0) {
-        c = this.getRange(pos-1, pos);
-        if (c !== '\n' && c !== LineSentinelCharacter)
-          break;
-        pos--;
-      }
-    }
-    var spans = this.annotationList_.getAnnotatedSpansForPos(pos);
-    this.currentAttributes_ = {};
+	RichTextCodeMirror.prototype.updateCurrentAttributes_ = function() {
+		var cm = this.codeMirror;
+		var anchor = cm.indexFromPos(cm.getCursor('anchor')), head = cm.indexFromPos(cm.getCursor('head'));
+		var pos = head;
+		var nextc=this.getRange(pos, pos+1);
+		var eol=(nextc=='\n' || nextc==''), sol=(pos==1 || this.getRange(pos-1, pos)==LineSentinelCharacter);
+		
+		if (sol && !eol) {
+			// beginning of a non empty line, look to the right
+		} else {
+			// look to the left, Back up before any newlines or line sentinels.
+			if (anchor > head) { // backwards selection
+				// Advance past any newlines or line sentinels.
+				while(pos < this.end()) {
+					var c = this.getRange(pos, pos+1);
+					if (c !== '\n' && c !== LineSentinelCharacter)
+						break;
+					pos++;
+				}
+				if (pos < this.end())
+					pos++; // since we're going to look at the annotation span to the left to decide what attributes to use.
+			} else {
+				// look to the left, Back up before any newlines or line sentinels.
+				while(pos > 0) {
+					c = this.getRange(pos-1, pos);
+					if (c !== '\n' && c !== LineSentinelCharacter)
+						break;
+					pos--;
+				}
+			}
+		}
 
-    var attributes = {};
-    // Use the attributes to the left unless they're line attributes (in which case use the ones to the right.
-    if (spans.length > 0 && (!(ATTR.LINE_SENTINEL in spans[0].annotation.attributes))) {
-      attributes = spans[0].annotation.attributes;
-    } else if (spans.length > 1) {
-      firepad.utils.assert(!(ATTR.LINE_SENTINEL in spans[1].annotation.attributes), "Cursor can't be between two line sentinel characters.");
-      attributes = spans[1].annotation.attributes;
-    }
-    for(var attr in attributes) {
-      // Don't copy line or entity attributes.
-      if (attr !== 'l' && attr !== 'lt' && attr !== 'li' && attr.indexOf(ATTR.ENTITY_SENTINEL) !== 0) {
-        this.currentAttributes_[attr] = attributes[attr];
-      }
-    }
-  };
+		var spans = this.annotationList_.getAnnotatedSpansForPos(pos);
+		var attributes = spans[0].annotation.attributes;
+	
+		this.currentAttributes_ = {};
+		for(var attr in attributes) {
+			// Don't copy line or entity attributes.
+			if (attr !== 'l' && attr !== 'lt' && attr !== 'li' && attr.indexOf(ATTR.ENTITY_SENTINEL) !== 0) {
+				this.currentAttributes_[attr] = attributes[attr];
+			}
+		}
+	};
 
   RichTextCodeMirror.prototype.getCurrentLineAttributes_ = function() {
     var cm = this.codeMirror;

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -927,34 +927,31 @@ firepad.RichTextCodeMirror = (function () {
       if (pos < this.end())
         pos++; // since we're going to look at the annotation span to the left to decide what attributes to use.
     } else {
-      var c, nextc=this.getRange(pos, pos+1);
-      var eol=(nextc=='\n' || nextc==''), sol=(pos==0 || this.getRange(pos-1, pos)==LineSentinelCharacter);
-      if (anchor==head && sol && !eol) {
-        // beginning of a non empty line (and not selection), look to the right
-        lookLeft=false;
-      } else {
-        // look to the left, Back up before any newlines or line sentinels.
-        while(pos > 0) {
-          nextc=c;
-          c = this.getRange(pos-1, pos);
-          if (c !== '\n' && c !== LineSentinelCharacter)  break;
-          pos--;
-        }
-        if (nextc=='\n') pos++; // we're just before a newline, advance to the newline
+			var c;
+  		// look to the left, Back up before any newlines or line sentinels.
+      while(pos > 0) {
+			  nextc=c;
+        c = this.getRange(pos-1, pos);
+				if (c !== '\n' && c !== LineSentinelCharacter)	break;
+        pos--;
       }
+			if (nextc=='\n') pos++; // we're just before a newline, advance to the newline
     }
 
     var spans = this.annotationList_.getAnnotatedSpansForPos(pos);
+    
+    // special case for head==0 or beginning of a non empty line (and not selection), look right if possible
+    var nextc=this.getRange(head, head+1), eol=(nextc=='\n' || nextc==''), sol=(this.getRange(head-1, head)==LineSentinelCharacter);
+    if (anchor==head && (head==0 || (sol && !eol))) lookLeft=(spans.length===1); 
+    
     this.currentAttributes_ = {};
     var attributes = {};
-    if (lookLeft && spans.length > 0 && (!(ATTR.LINE_SENTINEL in spans[0].annotation.attributes))) {    
+    if (lookLeft && spans.length > 0 && !(ATTR.LINE_SENTINEL in spans[0].annotation.attributes)) {    
       attributes = spans[0].annotation.attributes;
     } else if (!lookLeft && spans.length > 1) {   
       firepad.utils.assert(!(ATTR.LINE_SENTINEL in spans[1].annotation.attributes), "Cursor can't be between two line sentinel characters.");
       attributes = spans[1].annotation.attributes;
-    } else if (!lookLeft && pos===0 && spans.length > 0  && (!(ATTR.LINE_SENTINEL in spans[0].annotation.attributes))) {
-      attributes = spans[0].annotation.attributes;
-    }
+    } 
     for(var attr in attributes) {
       // Don't copy line or entity attributes.
       if (attr !== 'l' && attr !== 'lt' && attr !== 'li' && attr.indexOf(ATTR.ENTITY_SENTINEL) !== 0) {

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -1075,7 +1075,7 @@ firepad.RichTextCodeMirror = (function () {
     } else if (backspaceAtStartOfLine && indent && indent > 0) {
       this.unindent();
     } else {
-      if (cm.indexFromPos(cursorPos)<=1) return; // nothing to delete
+      //if (cm.indexFromPos(cursorPos)<=1) return; // nothing to delete
       this.updateCurrentAttributes_(); // refresh attribute from any previous deleteLeft
       // disable updateCurrentAttributes in the onNextCursorActivity triggered by deleteH
       this.doNotUpdateCurrentAttributesOnNextCursorActivity=true;

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -908,10 +908,12 @@ firepad.RichTextCodeMirror = (function () {
     var anchor = cm.indexFromPos(cm.getCursor('anchor')), head = cm.indexFromPos(cm.getCursor('head'));
     var pos = head;
     var nextc=this.getRange(pos, pos+1);
-    var eol=(nextc=='\n' || nextc==''), sol=(pos==1 || this.getRange(pos-1, pos)==LineSentinelCharacter);
-
+    var eol=(nextc=='\n' || nextc==''), sol=(pos==1 || this.getRange(pos-1, pos)==LineSentinelCharacter); // start/end of line
+    var lookLeft=true;
+    
     if (sol && !eol) {
       // beginning of a non empty line, look to the right
+      lookLeft=false;
     } else {
       // look to the left, Back up before any newlines or line sentinels.
       if (anchor > head) { // backwards selection
@@ -925,7 +927,7 @@ firepad.RichTextCodeMirror = (function () {
         if (pos < this.end())
           pos++; // since we're going to look at the annotation span to the left to decide what attributes to use.
       } else {
-  	// look to the left, Back up before any newlines or line sentinels.
+        // look to the left, Back up before any newlines or line sentinels.
         while(pos > 0) {
           c = this.getRange(pos-1, pos);
           if (c !== '\n' && c !== LineSentinelCharacter)
@@ -936,9 +938,14 @@ firepad.RichTextCodeMirror = (function () {
     }
 
     var spans = this.annotationList_.getAnnotatedSpansForPos(pos);
-    var attributes = spans[0].annotation.attributes;
-	
     this.currentAttributes_ = {};
+    var attributes = {};    
+    if (lookLeft && spans.length > 0 && (!(ATTR.LINE_SENTINEL in spans[0].annotation.attributes))) {    
+      attributes = spans[0].annotation.attributes;    
+    } else if (!lookLeft && spans.length > 1) {   
+      firepad.utils.assert(!(ATTR.LINE_SENTINEL in spans[1].annotation.attributes), "Cursor can't be between two line sentinel characters.");   
+      attributes = spans[1].annotation.attributes;    
+    }   
     for(var attr in attributes) {
       // Don't copy line or entity attributes.
       if (attr !== 'l' && attr !== 'lt' && attr !== 'li' && attr.indexOf(ATTR.ENTITY_SENTINEL) !== 0) {

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -927,7 +927,9 @@ firepad.RichTextCodeMirror = (function () {
         pos++; // since we're going to look at the annotation span to the left to decide what attributes to use.
     } else {
       // look to the left, Back up before any newlines or line sentinels.
+      var nextc=this.getRange(pos, pos+1);
       while(pos > 0) {
+        nextc=c;
         c = this.getRange(pos-1, pos);
         if (c !== '\n' && c !== LineSentinelCharacter) break;
         pos--;

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -914,7 +914,7 @@ firepad.RichTextCodeMirror = (function () {
   RichTextCodeMirror.prototype.updateCurrentAttributes_ = function() {
     var cm = this.codeMirror;
     var anchor = cm.indexFromPos(cm.getCursor('anchor')), head = cm.indexFromPos(cm.getCursor('head'));
-    var pos = head, c;
+    var pos = head, c='';
 
     if (anchor > head) { // backwards selection
       // Advance past any newlines or line sentinels.

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -6,9 +6,9 @@ firepad.RichTextCodeMirror = (function () {
   var utils = firepad.utils;
   var ATTR = firepad.AttributeConstants;
   var RichTextClassPrefixDefault = 'cmrt-';
-  var RichTextOriginPrefix = 'ctmrt-';
+  var RichTextOriginPrefix = 'cmrt-';
 
-  // These attributestoolbar.boldBtnElem will have styles generated dynamically in the page.
+  // These attributes will have styles generated dynamically in the page.
   var DynamicStyleAttributes = {
     'c' : 'color',
     'bc': 'background-color',
@@ -35,7 +35,6 @@ firepad.RichTextCodeMirror = (function () {
     bind(this, 'onCodeMirrorBeforeChange_');
     bind(this, 'onCodeMirrorChange_');
     bind(this, 'onCursorActivity_');
-    bind(this, 'onCodeMirrorKeyDown_');
 
     if (parseInt(CodeMirror.version) >= 4) {
       this.codeMirror.on('changes', this.onCodeMirrorChange_);
@@ -44,7 +43,6 @@ firepad.RichTextCodeMirror = (function () {
     }
     this.codeMirror.on('beforeChange', this.onCodeMirrorBeforeChange_);
     this.codeMirror.on('cursorActivity', this.onCursorActivity_);
-    this.codeMirror.on('keydown', this.onCodeMirrorKeyDown_);
 
     this.changeId_ = 0;
     this.outstandingChanges_ = { };
@@ -61,7 +59,6 @@ firepad.RichTextCodeMirror = (function () {
     this.codeMirror.off('change', this.onCodeMirrorChange_);
     this.codeMirror.off('changes', this.onCodeMirrorChange_);
     this.codeMirror.off('cursorActivity', this.onCursorActivity_);
-    this.codeMirror.off('keydown', this.onCodeMirrorKeyDown_);
     this.clearAnnotations_();
   };
 
@@ -897,17 +894,14 @@ firepad.RichTextCodeMirror = (function () {
   };
 
   RichTextCodeMirror.prototype.onCursorActivity_ = function() {
-    if (! this.lastKeyWasBackspace) {
+    var updateAttrs=!this.doNotUpdateCurrentAttributesOnNextCursorActivity;
+    this.doNotUpdateCurrentAttributesOnNextCursorActivity=false;
+    if (updateAttrs) {
       var self = this;
       setTimeout(function() {
         self.updateCurrentAttributes_();
       }, 1);
     }
-    this.lastKeyWasBackspace=false;
-  };
-
-  RichTextCodeMirror.prototype.onCodeMirrorKeyDown_ = function(cm, e) {
-    this.lastKeyWasBackspace= e.keyCode===8;
   };
 
   RichTextCodeMirror.prototype.getCurrentAttributes_ = function() {
@@ -987,7 +981,7 @@ firepad.RichTextCodeMirror = (function () {
       toggleClass(toolbar.italicBtnElem, 'firepad-btn-highlight', attr.i === true);
       toggleClass(toolbar.underlineBtnElem, 'firepad-btn-highlight', attr.u === true);
       toggleClass(toolbar.strikeBtnElem, 'firepad-btn-highlight', attr.s === true);
-    }, 200);
+    }, 100);
   }
 
   // If newState is provided add/remove theClass accordingly, otherwise toggle theClass
@@ -1081,7 +1075,10 @@ firepad.RichTextCodeMirror = (function () {
     } else if (backspaceAtStartOfLine && indent && indent > 0) {
       this.unindent();
     } else {
-      this.updateCurrentAttributes_(); // refresh attribute from any previous deleteLeft
+      // refresh attribute from any previous deleteLeft
+      this.updateCurrentAttributes_();
+      // disable updateCurrentAttributes in the onNextCursorActivity triggered by deleteH
+      this.doNotUpdateCurrentAttributesOnNextCursorActivity=true;
       cm.deleteH(-1, "char");
     }
   };

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -903,49 +903,49 @@ firepad.RichTextCodeMirror = (function () {
     return this.currentAttributes_;
   };
 
-	RichTextCodeMirror.prototype.updateCurrentAttributes_ = function() {
-		var cm = this.codeMirror;
-		var anchor = cm.indexFromPos(cm.getCursor('anchor')), head = cm.indexFromPos(cm.getCursor('head'));
-		var pos = head;
-		var nextc=this.getRange(pos, pos+1);
-		var eol=(nextc=='\n' || nextc==''), sol=(pos==1 || this.getRange(pos-1, pos)==LineSentinelCharacter);
-		
-		if (sol && !eol) {
-			// beginning of a non empty line, look to the right
-		} else {
-			// look to the left, Back up before any newlines or line sentinels.
-			if (anchor > head) { // backwards selection
-				// Advance past any newlines or line sentinels.
-				while(pos < this.end()) {
-					var c = this.getRange(pos, pos+1);
-					if (c !== '\n' && c !== LineSentinelCharacter)
-						break;
-					pos++;
-				}
-				if (pos < this.end())
-					pos++; // since we're going to look at the annotation span to the left to decide what attributes to use.
-			} else {
-				// look to the left, Back up before any newlines or line sentinels.
-				while(pos > 0) {
-					c = this.getRange(pos-1, pos);
-					if (c !== '\n' && c !== LineSentinelCharacter)
-						break;
-					pos--;
-				}
-			}
-		}
+  RichTextCodeMirror.prototype.updateCurrentAttributes_ = function() {
+    var cm = this.codeMirror;
+    var anchor = cm.indexFromPos(cm.getCursor('anchor')), head = cm.indexFromPos(cm.getCursor('head'));
+    var pos = head;
+    var nextc=this.getRange(pos, pos+1);
+    var eol=(nextc=='\n' || nextc==''), sol=(pos==1 || this.getRange(pos-1, pos)==LineSentinelCharacter);
 
-		var spans = this.annotationList_.getAnnotatedSpansForPos(pos);
-		var attributes = spans[0].annotation.attributes;
+    if (sol && !eol) {
+      // beginning of a non empty line, look to the right
+    } else {
+      // look to the left, Back up before any newlines or line sentinels.
+      if (anchor > head) { // backwards selection
+        // Advance past any newlines or line sentinels.
+        while(pos < this.end()) {
+          var c = this.getRange(pos, pos+1);
+          if (c !== '\n' && c !== LineSentinelCharacter)
+            break;
+          pos++;
+        }
+        if (pos < this.end())
+          pos++; // since we're going to look at the annotation span to the left to decide what attributes to use.
+      } else {
+  	// look to the left, Back up before any newlines or line sentinels.
+        while(pos > 0) {
+          c = this.getRange(pos-1, pos);
+          if (c !== '\n' && c !== LineSentinelCharacter)
+            break;
+          pos--;
+        }
+      }
+    }
+
+    var spans = this.annotationList_.getAnnotatedSpansForPos(pos);
+    var attributes = spans[0].annotation.attributes;
 	
-		this.currentAttributes_ = {};
-		for(var attr in attributes) {
-			// Don't copy line or entity attributes.
-			if (attr !== 'l' && attr !== 'lt' && attr !== 'li' && attr.indexOf(ATTR.ENTITY_SENTINEL) !== 0) {
-				this.currentAttributes_[attr] = attributes[attr];
-			}
-		}
-	};
+    this.currentAttributes_ = {};
+    for(var attr in attributes) {
+      // Don't copy line or entity attributes.
+      if (attr !== 'l' && attr !== 'lt' && attr !== 'li' && attr.indexOf(ATTR.ENTITY_SENTINEL) !== 0) {
+        this.currentAttributes_[attr] = attributes[attr];
+      }
+    }
+  };
 
   RichTextCodeMirror.prototype.getCurrentLineAttributes_ = function() {
     var cm = this.codeMirror;

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -914,19 +914,18 @@ firepad.RichTextCodeMirror = (function () {
   RichTextCodeMirror.prototype.updateCurrentAttributes_ = function() {
     var cm = this.codeMirror;
     var anchor = cm.indexFromPos(cm.getCursor('anchor')), head = cm.indexFromPos(cm.getCursor('head'));
-    var pos = head;
+    var pos = head, c;
 
     if (anchor > head) { // backwards selection
       // Advance past any newlines or line sentinels.
       while(pos < this.end()) {
-        var c = this.getRange(pos, pos+1);
+        c = this.getRange(pos, pos+1);
         if (c !== '\n' && c !== LineSentinelCharacter) break;
         pos++;
       }
       if (pos < this.end())
         pos++; // since we're going to look at the annotation span to the left to decide what attributes to use.
     } else {
-      var c;
       // look to the left, Back up before any newlines or line sentinels.
       while(pos > 0) {
         nextc=c;

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -937,7 +937,7 @@ firepad.RichTextCodeMirror = (function () {
 
     var spans, lookLeft;
     var nextc=this.getRange(head, head+1), eol=(nextc==='\n' || nextc===''), sol=(this.getRange(head-1, head)==LineSentinelCharacter);
-    if (anchor==head && (head==0 || (sol && !eol))) {
+    if (anchor==head && (head===0 || (sol && !eol))) {
       // special case for head==0 or beginning of a non empty line (and not selection), look right if possible
       spans = this.annotationList_.getAnnotatedSpansForPos(head);
       lookLeft=(spans.length===1); 
@@ -992,7 +992,7 @@ firepad.RichTextCodeMirror = (function () {
 
     elem.className = elem.className.replace(matchRegExp, ''); // clear all
     if (add) elem.className += ' ' + theClass;
-  };
+  }
 
   RichTextCodeMirror.prototype.getCurrentLineAttributes_ = function() {
     var cm = this.codeMirror;

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -915,7 +915,6 @@ firepad.RichTextCodeMirror = (function () {
     var cm = this.codeMirror;
     var anchor = cm.indexFromPos(cm.getCursor('anchor')), head = cm.indexFromPos(cm.getCursor('head'));
     var pos = head;
-    var lookLeft=true;
 
     if (anchor > head) { // backwards selection
       // Advance past any newlines or line sentinels.
@@ -927,20 +926,21 @@ firepad.RichTextCodeMirror = (function () {
       if (pos < this.end())
         pos++; // since we're going to look at the annotation span to the left to decide what attributes to use.
     } else {
-			var c;
-  		// look to the left, Back up before any newlines or line sentinels.
+      var c;
+      // look to the left, Back up before any newlines or line sentinels.
       while(pos > 0) {
-			  nextc=c;
+        nextc=c;
         c = this.getRange(pos-1, pos);
-				if (c !== '\n' && c !== LineSentinelCharacter)	break;
+        if (c !== '\n' && c !== LineSentinelCharacter) break;
         pos--;
       }
-			if (nextc=='\n') pos++; // we're just before a newline, advance to the newline
+      if (nextc=='\n') pos++; // we're just before a newline, advance to the newline
     }
 
     var spans = this.annotationList_.getAnnotatedSpansForPos(pos);
     
     // special case for head==0 or beginning of a non empty line (and not selection), look right if possible
+    var lookLeft=true;
     var nextc=this.getRange(head, head+1), eol=(nextc=='\n' || nextc==''), sol=(this.getRange(head-1, head)==LineSentinelCharacter);
     if (anchor==head && (head==0 || (sol && !eol))) lookLeft=(spans.length===1); 
     

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -1076,7 +1076,6 @@ firepad.RichTextCodeMirror = (function () {
     } else if (backspaceAtStartOfLine && indent && indent > 0) {
       this.unindent();
     } else {
-      var charLeft=cm.getRange({line: cursorPos.line, ch: cursorPos.ch-1}, cursorPos);
       if (cursorPos.line === cursorPos.ch === 0) return; // nothing to delete
       this.updateCurrentAttributes_(); // refresh attribute from any previous deleteLeft
       // disable updateCurrentAttributes in the onNextCursorActivity triggered by deleteH

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -8,7 +8,7 @@ firepad.RichTextCodeMirror = (function () {
   var RichTextClassPrefixDefault = 'cmrt-';
   var RichTextOriginPrefix = 'cmrt-';
 
-  // These attributes will have styles generated dynamically in the page.
+  // These attributestoolbar.boldBtnElem will have styles generated dynamically in the page.
   var DynamicStyleAttributes = {
     'c' : 'color',
     'bc': 'background-color',
@@ -971,6 +971,7 @@ firepad.RichTextCodeMirror = (function () {
 
   RichTextCodeMirror.prototype.updateToolbarButnsState_ = function() {
     var toolbar=this.codeMirror.firepad.toolbar;
+    if (!toolbar) return;
     var attr=this.currentAttributes_;
 
     if (!toolbar.boldBtnElem) { // cache button elements

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -940,7 +940,7 @@ firepad.RichTextCodeMirror = (function () {
     if (anchor==head && (head===0 || (sol && !eol))) {
       // special case for head==0 or beginning of a non empty line (and not selection), look right if possible
       spans = this.annotationList_.getAnnotatedSpansForPos(head);
-      lookLeft=(spans.length===1); 
+      lookLeft=(spans.length<2); 
     } else {
       lookLeft=true;
       spans = this.annotationList_.getAnnotatedSpansForPos(pos);

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -946,10 +946,10 @@ firepad.RichTextCodeMirror = (function () {
     var attributes = {};
     if (lookLeft && spans.length > 0 && !(ATTR.LINE_SENTINEL in spans[0].annotation.attributes)) {    
       attributes = spans[0].annotation.attributes;
-    } else if (!lookLeft && spans.length > 1) {   
+    } else if (!lookLeft && spans.length > 1) {
       firepad.utils.assert(!(ATTR.LINE_SENTINEL in spans[1].annotation.attributes), "Cursor can't be between two line sentinel characters.");
       attributes = spans[1].annotation.attributes;
-    } 
+    }
     for(var attr in attributes) {
       // Don't copy line or entity attributes.
       if (attr !== 'l' && attr !== 'lt' && attr !== 'li' && attr.indexOf(ATTR.ENTITY_SENTINEL) !== 0) {

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -907,33 +907,32 @@ firepad.RichTextCodeMirror = (function () {
     var cm = this.codeMirror;
     var anchor = cm.indexFromPos(cm.getCursor('anchor')), head = cm.indexFromPos(cm.getCursor('head'));
     var pos = head;
-    var nextc=this.getRange(pos, pos+1);
-    var eol=(nextc=='\n' || nextc==''), sol=(pos==1 || this.getRange(pos-1, pos)==LineSentinelCharacter); // start/end of line
     var lookLeft=true;
-    
-    if (sol && !eol) {
-      // beginning of a non empty line, look to the right
-      lookLeft=false;
+
+    if (anchor > head) { // backwards selection
+      // Advance past any newlines or line sentinels.
+      while(pos < this.end()) {
+        var c = this.getRange(pos, pos+1);
+        if (c !== '\n' && c !== LineSentinelCharacter) break;
+        pos++;
+      }
+      if (pos < this.end())
+      pos++; // since we're going to look at the annotation span to the left to decide what attributes to use.
     } else {
-      // look to the left, Back up before any newlines or line sentinels.
-      if (anchor > head) { // backwards selection
-        // Advance past any newlines or line sentinels.
-        while(pos < this.end()) {
-          var c = this.getRange(pos, pos+1);
-          if (c !== '\n' && c !== LineSentinelCharacter)
-            break;
-          pos++;
-        }
-        if (pos < this.end())
-          pos++; // since we're going to look at the annotation span to the left to decide what attributes to use.
+      var c, nextc=this.getRange(pos, pos+1);
+      var eol=(nextc=='\n' || nextc==''), sol=(pos==1 || this.getRange(pos-1, pos)==LineSentinelCharacter);
+      if (anchor==head && sol && !eol) {
+        // beginning of a non empty line (and not selection), look to the right
+        lookLeft=false;
       } else {
         // look to the left, Back up before any newlines or line sentinels.
         while(pos > 0) {
+          nextc=c;
           c = this.getRange(pos-1, pos);
-          if (c !== '\n' && c !== LineSentinelCharacter)
-            break;
+          if (c !== '\n' && c !== LineSentinelCharacter)  break;
           pos--;
         }
+        if (nextc=='\n') pos++; // we're just before a newline, advance to the newline
       }
     }
 
@@ -953,7 +952,7 @@ firepad.RichTextCodeMirror = (function () {
       }
     }
   };
-
+  
   RichTextCodeMirror.prototype.getCurrentLineAttributes_ = function() {
     var cm = this.codeMirror;
     var anchor = cm.getCursor('anchor'), head = cm.getCursor('head');

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -35,7 +35,7 @@ firepad.RichTextCodeMirror = (function () {
     bind(this, 'onCodeMirrorBeforeChange_');
     bind(this, 'onCodeMirrorChange_');
     bind(this, 'onCursorActivity_');
-		bind(this, 'onCodeMirrorKeyDown_');
+    bind(this, 'onCodeMirrorKeyDown_');
 
     if (parseInt(CodeMirror.version) >= 4) {
       this.codeMirror.on('changes', this.onCodeMirrorChange_);
@@ -44,7 +44,7 @@ firepad.RichTextCodeMirror = (function () {
     }
     this.codeMirror.on('beforeChange', this.onCodeMirrorBeforeChange_);
     this.codeMirror.on('cursorActivity', this.onCursorActivity_);
-		this.codeMirror.on('keydown', this.onCodeMirrorKeyDown_);
+    this.codeMirror.on('keydown', this.onCodeMirrorKeyDown_);
 
     this.changeId_ = 0;
     this.outstandingChanges_ = { };
@@ -61,7 +61,7 @@ firepad.RichTextCodeMirror = (function () {
     this.codeMirror.off('change', this.onCodeMirrorChange_);
     this.codeMirror.off('changes', this.onCodeMirrorChange_);
     this.codeMirror.off('cursorActivity', this.onCursorActivity_);
-		this.codeMirror.off('keydown', this.onCodeMirrorKeyDown_);
+    this.codeMirror.off('keydown', this.onCodeMirrorKeyDown_);
     this.clearAnnotations_();
   };
 
@@ -75,7 +75,7 @@ firepad.RichTextCodeMirror = (function () {
         attrs[attribute] = trueValue;
       }
       this.currentAttributes_ = attrs;
-			this.updateToolbarButnsState_();
+      this.updateToolbarButnsState_();
 
     } else {
       var attributes = this.getCurrentAttributes_();
@@ -94,7 +94,7 @@ firepad.RichTextCodeMirror = (function () {
         attrs[attribute] = value;
       }
       this.currentAttributes_ = attrs;
-			this.updateToolbarButnsState_();
+      this.updateToolbarButnsState_();
 
     } else {
       this.updateTextAttributes(cm.indexFromPos(cm.getCursor('start')), cm.indexFromPos(cm.getCursor('end')),
@@ -897,17 +897,17 @@ firepad.RichTextCodeMirror = (function () {
   };
 
   RichTextCodeMirror.prototype.onCursorActivity_ = function() {
-		if (! this.lastKeyWasBackspace) {
-    var self = this;
-    setTimeout(function() {
-      self.updateCurrentAttributes_();
-    }, 1);
-		}
-		this.lastKeyWasBackspace=false;
-	};
+    if (! this.lastKeyWasBackspace) {
+      var self = this;
+      setTimeout(function() {
+        self.updateCurrentAttributes_();
+      }, 1);
+    }
+    this.lastKeyWasBackspace=false;
+  };
 
-	RichTextCodeMirror.prototype.onCodeMirrorKeyDown_ = function(cm, e) {
-		this.lastKeyWasBackspace= e.keyCode===8;
+  RichTextCodeMirror.prototype.onCodeMirrorKeyDown_ = function(cm, e) {
+    this.lastKeyWasBackspace= e.keyCode===8;
   };
 
   RichTextCodeMirror.prototype.getCurrentAttributes_ = function() {
@@ -921,41 +921,41 @@ firepad.RichTextCodeMirror = (function () {
     var cm = this.codeMirror;
     var anchor = cm.indexFromPos(cm.getCursor('anchor')), head = cm.indexFromPos(cm.getCursor('head'));
     var pos = head;
-		var lookLeft=true;
+    var lookLeft=true;
 
     if (anchor > head) { // backwards selection
       // Advance past any newlines or line sentinels.
       while(pos < this.end()) {
         var c = this.getRange(pos, pos+1);
-				if (c !== '\n' && c !== LineSentinelCharacter) break;
+        if (c !== '\n' && c !== LineSentinelCharacter) break;
         pos++;
       }
       if (pos < this.end())
         pos++; // since we're going to look at the annotation span to the left to decide what attributes to use.
     } else {
-			var c, nextc=this.getRange(pos, pos+1);
-			var eol=(nextc=='\n' || nextc==''), sol=(pos==1 || this.getRange(pos-1, pos)==LineSentinelCharacter);
-			if (anchor==head && sol && !eol) {
-				// beginning of a non empty line (and not selection), look to the right
-				lookLeft=false;
-			} else {
-				// look to the left, Back up before any newlines or line sentinels.
+      var c, nextc=this.getRange(pos, pos+1);
+      var eol=(nextc=='\n' || nextc==''), sol=(pos==1 || this.getRange(pos-1, pos)==LineSentinelCharacter);
+      if (anchor==head && sol && !eol) {
+        // beginning of a non empty line (and not selection), look to the right
+        lookLeft=false;
+      } else {
+        // look to the left, Back up before any newlines or line sentinels.
       while(pos > 0) {
-					nextc=c;
+          nextc=c;
         c = this.getRange(pos-1, pos);
-					if (c !== '\n' && c !== LineSentinelCharacter)	break;
+          if (c !== '\n' && c !== LineSentinelCharacter)  break;
         pos--;
       }
-				if (nextc=='\n') pos++; // we're just before a newline, advance to the newline
-			}
+        if (nextc=='\n') pos++; // we're just before a newline, advance to the newline
+      }
     }
 
     var spans = this.annotationList_.getAnnotatedSpansForPos(pos);
     this.currentAttributes_ = {};
     var attributes = {};
-		if (lookLeft && spans.length > 0 && (!(ATTR.LINE_SENTINEL in spans[0].annotation.attributes))) {		
+    if (lookLeft && spans.length > 0 && (!(ATTR.LINE_SENTINEL in spans[0].annotation.attributes))) {    
       attributes = spans[0].annotation.attributes;
-		} else if (!lookLeft && spans.length > 1) {		
+    } else if (!lookLeft && spans.length > 1) {   
       firepad.utils.assert(!(ATTR.LINE_SENTINEL in spans[1].annotation.attributes), "Cursor can't be between two line sentinel characters.");
       attributes = spans[1].annotation.attributes;
     }
@@ -966,37 +966,37 @@ firepad.RichTextCodeMirror = (function () {
       }
     }
 
-		this.updateToolbarButnsState_();
+    this.updateToolbarButnsState_();
   };
 
-	RichTextCodeMirror.prototype.updateToolbarButnsState_ = function() {
-		var toolbar=this.codeMirror.firepad.toolbar;
-		var attr=this.currentAttributes_;
+  RichTextCodeMirror.prototype.updateToolbarButnsState_ = function() {
+    var toolbar=this.codeMirror.firepad.toolbar;
+    var attr=this.currentAttributes_;
 
-		if (!toolbar.boldBtnElem) { // cache button elements
-			toolbar.boldBtnElem = toolbar.element_.getElementsByClassName('firepad-tb-bold')[0].parentElement;
-			toolbar.italicBtnElem = toolbar.element_.getElementsByClassName('firepad-tb-italic')[0].parentElement;
-			toolbar.underlineBtnElem = toolbar.element_.getElementsByClassName('firepad-tb-underline')[0].parentElement;
-			toolbar.strikeBtnElem = toolbar.element_.getElementsByClassName('firepad-tb-strikethrough')[0].parentElement;
-		}
+    if (!toolbar.boldBtnElem) { // cache button elements
+      toolbar.boldBtnElem = toolbar.element_.getElementsByClassName('firepad-tb-bold')[0].parentElement;
+      toolbar.italicBtnElem = toolbar.element_.getElementsByClassName('firepad-tb-italic')[0].parentElement;
+      toolbar.underlineBtnElem = toolbar.element_.getElementsByClassName('firepad-tb-underline')[0].parentElement;
+      toolbar.strikeBtnElem = toolbar.element_.getElementsByClassName('firepad-tb-strikethrough')[0].parentElement;
+    }
 
-		if (toolbar.updateToolbarButnsStateTimeout) clearTimeout(toolbar.updateToolbarButnsStateTimeout);
-		toolbar.updateToolbarButnsStateTimeout = setTimeout(function() {
-			toggleClass(toolbar.boldBtnElem, 'firepad-btn-highlight', attr.b === true);
-			toggleClass(toolbar.italicBtnElem, 'firepad-btn-highlight', attr.i === true);
-			toggleClass(toolbar.underlineBtnElem, 'firepad-btn-highlight', attr.u === true);
-			toggleClass(toolbar.strikeBtnElem, 'firepad-btn-highlight', attr.s === true);
-		}, 200);
-	}
+    if (toolbar.updateToolbarButnsStateTimeout) clearTimeout(toolbar.updateToolbarButnsStateTimeout);
+    toolbar.updateToolbarButnsStateTimeout = setTimeout(function() {
+      toggleClass(toolbar.boldBtnElem, 'firepad-btn-highlight', attr.b === true);
+      toggleClass(toolbar.italicBtnElem, 'firepad-btn-highlight', attr.i === true);
+      toggleClass(toolbar.underlineBtnElem, 'firepad-btn-highlight', attr.u === true);
+      toggleClass(toolbar.strikeBtnElem, 'firepad-btn-highlight', attr.s === true);
+    }, 200);
+  }
 
-	// If newState is provided add/remove theClass accordingly, otherwise toggle theClass
-	function toggleClass(elem, theClass, newState) {
-		let matchRegExp = new RegExp('(?:^|\\s)' + theClass + '(?!\\S)', 'g');
-		let add = (arguments.length > 2 ? newState : (elem.className.match(matchRegExp) === null));
+  // If newState is provided add/remove theClass accordingly, otherwise toggle theClass
+  function toggleClass(elem, theClass, newState) {
+    let matchRegExp = new RegExp('(?:^|\\s)' + theClass + '(?!\\S)', 'g');
+    let add = (arguments.length > 2 ? newState : (elem.className.match(matchRegExp) === null));
 
-		elem.className = elem.className.replace(matchRegExp, ''); // clear all
-		if (add) elem.className += ' ' + theClass;
-	}
+    elem.className = elem.className.replace(matchRegExp, ''); // clear all
+    if (add) elem.className += ' ' + theClass;
+  }
 
   RichTextCodeMirror.prototype.getCurrentLineAttributes_ = function() {
     var cm = this.codeMirror;
@@ -1080,7 +1080,7 @@ firepad.RichTextCodeMirror = (function () {
     } else if (backspaceAtStartOfLine && indent && indent > 0) {
       this.unindent();
     } else {
-			this.updateCurrentAttributes_(); // refresh attribute from any previous deleteLeft
+      this.updateCurrentAttributes_(); // refresh attribute from any previous deleteLeft
       cm.deleteH(-1, "char");
     }
   };

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -6,7 +6,7 @@ firepad.RichTextCodeMirror = (function () {
   var utils = firepad.utils;
   var ATTR = firepad.AttributeConstants;
   var RichTextClassPrefixDefault = 'cmrt-';
-  var RichTextOriginPrefix = 'cmrt-';
+  var RichTextOriginPrefix = 'ctmrt-';
 
   // These attributestoolbar.boldBtnElem will have styles generated dynamically in the page.
   var DynamicStyleAttributes = {
@@ -970,7 +970,7 @@ firepad.RichTextCodeMirror = (function () {
   };
 
   RichTextCodeMirror.prototype.updateToolbarButnsState_ = function() {
-		if (!this.codeMirror || !this.codeMirror.firepad || !this.codeMirror.firepad.toolbar) return;
+    if (!this.codeMirror || !this.codeMirror.firepad || !this.codeMirror.firepad.toolbar) return;
     var toolbar=this.codeMirror.firepad.toolbar;
     var attr=this.currentAttributes_;
 

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -936,7 +936,7 @@ firepad.RichTextCodeMirror = (function () {
     }
 
     var spans, lookLeft;
-    var nextc=this.getRange(head, head+1), eol=(nextc=='\n' || nextc==''), sol=(this.getRange(head-1, head)==LineSentinelCharacter);
+    var nextc=this.getRange(head, head+1), eol=(nextc==='\n' || nextc===''), sol=(this.getRange(head-1, head)==LineSentinelCharacter);
     if (anchor==head && (head==0 || (sol && !eol))) {
       // special case for head==0 or beginning of a non empty line (and not selection), look right if possible
       spans = this.annotationList_.getAnnotatedSpansForPos(head);

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -916,8 +916,7 @@ firepad.RichTextCodeMirror = (function () {
         if (c !== '\n' && c !== LineSentinelCharacter) break;
         pos++;
       }
-      if (pos < this.end())
-      pos++; // since we're going to look at the annotation span to the left to decide what attributes to use.
+      if (pos < this.end()) pos++; // since we're going to look at the annotation span to the left to decide what attributes to use.
     } else {
       var c, nextc=this.getRange(pos, pos+1);
       var eol=(nextc=='\n' || nextc==''), sol=(pos==1 || this.getRange(pos-1, pos)==LineSentinelCharacter);

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -1077,7 +1077,7 @@ firepad.RichTextCodeMirror = (function () {
       this.unindent();
     } else {
       var charLeft=cm.getRange({line: cursorPos.line, ch: cursorPos.ch-1}, cursorPos);
-      if (charLeft==='') return; // nothing to delete
+      if (cursorPos.line === cursorPos.ch === 0) return; // nothing to delete
       this.updateCurrentAttributes_(); // refresh attribute from any previous deleteLeft
       // disable updateCurrentAttributes in the onNextCursorActivity triggered by deleteH
       this.doNotUpdateCurrentAttributesOnNextCursorActivity=true;

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -928,7 +928,6 @@ firepad.RichTextCodeMirror = (function () {
     } else {
       // look to the left, Back up before any newlines or line sentinels.
       while(pos > 0) {
-        nextc=c;
         c = this.getRange(pos-1, pos);
         if (c !== '\n' && c !== LineSentinelCharacter) break;
         pos--;

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -928,18 +928,18 @@ firepad.RichTextCodeMirror = (function () {
         pos++; // since we're going to look at the annotation span to the left to decide what attributes to use.
     } else {
       var c, nextc=this.getRange(pos, pos+1);
-      var eol=(nextc=='\n' || nextc==''), sol=(pos==1 || this.getRange(pos-1, pos)==LineSentinelCharacter);
+      var eol=(nextc=='\n' || nextc==''), sol=(pos==0 || this.getRange(pos-1, pos)==LineSentinelCharacter);
       if (anchor==head && sol && !eol) {
         // beginning of a non empty line (and not selection), look to the right
         lookLeft=false;
       } else {
         // look to the left, Back up before any newlines or line sentinels.
-      while(pos > 0) {
+        while(pos > 0) {
           nextc=c;
-        c = this.getRange(pos-1, pos);
+          c = this.getRange(pos-1, pos);
           if (c !== '\n' && c !== LineSentinelCharacter)  break;
-        pos--;
-      }
+          pos--;
+        }
         if (nextc=='\n') pos++; // we're just before a newline, advance to the newline
       }
     }
@@ -952,6 +952,8 @@ firepad.RichTextCodeMirror = (function () {
     } else if (!lookLeft && spans.length > 1) {   
       firepad.utils.assert(!(ATTR.LINE_SENTINEL in spans[1].annotation.attributes), "Cursor can't be between two line sentinel characters.");
       attributes = spans[1].annotation.attributes;
+    } else if (!lookLeft && pos===0 && spans.length > 0  && (!(ATTR.LINE_SENTINEL in spans[0].annotation.attributes))) {
+      attributes = spans[0].annotation.attributes;
     }
     for(var attr in attributes) {
       // Don't copy line or entity attributes.
@@ -1075,7 +1077,8 @@ firepad.RichTextCodeMirror = (function () {
     } else if (backspaceAtStartOfLine && indent && indent > 0) {
       this.unindent();
     } else {
-      //if (cm.indexFromPos(cursorPos)<=1) return; // nothing to delete
+      var charLeft=cm.getRange({line: cursorPos.line, ch: cursorPos.ch-1}, cursorPos);
+      if (charLeft==='') return; // nothing to delete
       this.updateCurrentAttributes_(); // refresh attribute from any previous deleteLeft
       // disable updateCurrentAttributes in the onNextCursorActivity triggered by deleteH
       this.doNotUpdateCurrentAttributesOnNextCursorActivity=true;

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -35,6 +35,7 @@ firepad.RichTextCodeMirror = (function () {
     bind(this, 'onCodeMirrorBeforeChange_');
     bind(this, 'onCodeMirrorChange_');
     bind(this, 'onCursorActivity_');
+		bind(this, 'onCodeMirrorKeyDown_');
 
     if (parseInt(CodeMirror.version) >= 4) {
       this.codeMirror.on('changes', this.onCodeMirrorChange_);
@@ -43,6 +44,7 @@ firepad.RichTextCodeMirror = (function () {
     }
     this.codeMirror.on('beforeChange', this.onCodeMirrorBeforeChange_);
     this.codeMirror.on('cursorActivity', this.onCursorActivity_);
+		this.codeMirror.on('keydown', this.onCodeMirrorKeyDown_);
 
     this.changeId_ = 0;
     this.outstandingChanges_ = { };
@@ -59,6 +61,7 @@ firepad.RichTextCodeMirror = (function () {
     this.codeMirror.off('change', this.onCodeMirrorChange_);
     this.codeMirror.off('changes', this.onCodeMirrorChange_);
     this.codeMirror.off('cursorActivity', this.onCursorActivity_);
+		this.codeMirror.off('keydown', this.onCodeMirrorKeyDown_);
     this.clearAnnotations_();
   };
 
@@ -72,6 +75,8 @@ firepad.RichTextCodeMirror = (function () {
         attrs[attribute] = trueValue;
       }
       this.currentAttributes_ = attrs;
+			this.updateToolbarButnsState_();
+
     } else {
       var attributes = this.getCurrentAttributes_();
       var newValue = (attributes[attribute] !== trueValue) ? trueValue : false;
@@ -89,6 +94,8 @@ firepad.RichTextCodeMirror = (function () {
         attrs[attribute] = value;
       }
       this.currentAttributes_ = attrs;
+			this.updateToolbarButnsState_();
+
     } else {
       this.updateTextAttributes(cm.indexFromPos(cm.getCursor('start')), cm.indexFromPos(cm.getCursor('end')),
         function(attributes) {
@@ -890,10 +897,17 @@ firepad.RichTextCodeMirror = (function () {
   };
 
   RichTextCodeMirror.prototype.onCursorActivity_ = function() {
+		if (! this.lastKeyWasBackspace) {
     var self = this;
     setTimeout(function() {
       self.updateCurrentAttributes_();
     }, 1);
+		}
+		this.lastKeyWasBackspace=false;
+	};
+
+	RichTextCodeMirror.prototype.onCodeMirrorKeyDown_ = function(cm, e) {
+		this.lastKeyWasBackspace= e.keyCode===8;
   };
 
   RichTextCodeMirror.prototype.getCurrentAttributes_ = function() {
@@ -907,51 +921,83 @@ firepad.RichTextCodeMirror = (function () {
     var cm = this.codeMirror;
     var anchor = cm.indexFromPos(cm.getCursor('anchor')), head = cm.indexFromPos(cm.getCursor('head'));
     var pos = head;
-    var lookLeft=true;
+		var lookLeft=true;
 
     if (anchor > head) { // backwards selection
       // Advance past any newlines or line sentinels.
       while(pos < this.end()) {
         var c = this.getRange(pos, pos+1);
-        if (c !== '\n' && c !== LineSentinelCharacter) break;
+				if (c !== '\n' && c !== LineSentinelCharacter) break;
         pos++;
       }
-      if (pos < this.end()) pos++; // since we're going to look at the annotation span to the left to decide what attributes to use.
+      if (pos < this.end())
+        pos++; // since we're going to look at the annotation span to the left to decide what attributes to use.
     } else {
-      var c, nextc=this.getRange(pos, pos+1);
-      var eol=(nextc=='\n' || nextc==''), sol=(pos==1 || this.getRange(pos-1, pos)==LineSentinelCharacter);
-      if (anchor==head && sol && !eol) {
-        // beginning of a non empty line (and not selection), look to the right
-        lookLeft=false;
-      } else {
-        // look to the left, Back up before any newlines or line sentinels.
-        while(pos > 0) {
-          nextc=c;
-          c = this.getRange(pos-1, pos);
-          if (c !== '\n' && c !== LineSentinelCharacter)  break;
-          pos--;
-        }
-        if (nextc=='\n') pos++; // we're just before a newline, advance to the newline
+			var c, nextc=this.getRange(pos, pos+1);
+			var eol=(nextc=='\n' || nextc==''), sol=(pos==1 || this.getRange(pos-1, pos)==LineSentinelCharacter);
+			if (anchor==head && sol && !eol) {
+				// beginning of a non empty line (and not selection), look to the right
+				lookLeft=false;
+			} else {
+				// look to the left, Back up before any newlines or line sentinels.
+      while(pos > 0) {
+					nextc=c;
+        c = this.getRange(pos-1, pos);
+					if (c !== '\n' && c !== LineSentinelCharacter)	break;
+        pos--;
       }
+				if (nextc=='\n') pos++; // we're just before a newline, advance to the newline
+			}
     }
 
     var spans = this.annotationList_.getAnnotatedSpansForPos(pos);
     this.currentAttributes_ = {};
-    var attributes = {};    
-    if (lookLeft && spans.length > 0 && (!(ATTR.LINE_SENTINEL in spans[0].annotation.attributes))) {    
-      attributes = spans[0].annotation.attributes;    
-    } else if (!lookLeft && spans.length > 1) {   
-      firepad.utils.assert(!(ATTR.LINE_SENTINEL in spans[1].annotation.attributes), "Cursor can't be between two line sentinel characters.");   
-      attributes = spans[1].annotation.attributes;    
-    }   
+    var attributes = {};
+		if (lookLeft && spans.length > 0 && (!(ATTR.LINE_SENTINEL in spans[0].annotation.attributes))) {		
+      attributes = spans[0].annotation.attributes;
+		} else if (!lookLeft && spans.length > 1) {		
+      firepad.utils.assert(!(ATTR.LINE_SENTINEL in spans[1].annotation.attributes), "Cursor can't be between two line sentinel characters.");
+      attributes = spans[1].annotation.attributes;
+    }
     for(var attr in attributes) {
       // Don't copy line or entity attributes.
       if (attr !== 'l' && attr !== 'lt' && attr !== 'li' && attr.indexOf(ATTR.ENTITY_SENTINEL) !== 0) {
         this.currentAttributes_[attr] = attributes[attr];
       }
     }
+
+		this.updateToolbarButnsState_();
   };
-  
+
+	RichTextCodeMirror.prototype.updateToolbarButnsState_ = function() {
+		var toolbar=this.codeMirror.firepad.toolbar;
+		var attr=this.currentAttributes_;
+
+		if (!toolbar.boldBtnElem) { // cache button elements
+			toolbar.boldBtnElem = toolbar.element_.getElementsByClassName('firepad-tb-bold')[0].parentElement;
+			toolbar.italicBtnElem = toolbar.element_.getElementsByClassName('firepad-tb-italic')[0].parentElement;
+			toolbar.underlineBtnElem = toolbar.element_.getElementsByClassName('firepad-tb-underline')[0].parentElement;
+			toolbar.strikeBtnElem = toolbar.element_.getElementsByClassName('firepad-tb-strikethrough')[0].parentElement;
+		}
+
+		if (toolbar.updateToolbarButnsStateTimeout) clearTimeout(toolbar.updateToolbarButnsStateTimeout);
+		toolbar.updateToolbarButnsStateTimeout = setTimeout(function() {
+			toggleClass(toolbar.boldBtnElem, 'firepad-btn-highlight', attr.b === true);
+			toggleClass(toolbar.italicBtnElem, 'firepad-btn-highlight', attr.i === true);
+			toggleClass(toolbar.underlineBtnElem, 'firepad-btn-highlight', attr.u === true);
+			toggleClass(toolbar.strikeBtnElem, 'firepad-btn-highlight', attr.s === true);
+		}, 200);
+	}
+
+	// If newState is provided add/remove theClass accordingly, otherwise toggle theClass
+	function toggleClass(elem, theClass, newState) {
+		let matchRegExp = new RegExp('(?:^|\\s)' + theClass + '(?!\\S)', 'g');
+		let add = (arguments.length > 2 ? newState : (elem.className.match(matchRegExp) === null));
+
+		elem.className = elem.className.replace(matchRegExp, ''); // clear all
+		if (add) elem.className += ' ' + theClass;
+	}
+
   RichTextCodeMirror.prototype.getCurrentLineAttributes_ = function() {
     var cm = this.codeMirror;
     var anchor = cm.getCursor('anchor'), head = cm.getCursor('head');
@@ -1034,6 +1080,7 @@ firepad.RichTextCodeMirror = (function () {
     } else if (backspaceAtStartOfLine && indent && indent > 0) {
       this.unindent();
     } else {
+			this.updateCurrentAttributes_(); // refresh attribute from any previous deleteLeft
       cm.deleteH(-1, "char");
     }
   };

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -1060,7 +1060,6 @@ firepad.RichTextCodeMirror = (function () {
   RichTextCodeMirror.prototype.deleteLeft = function() {
     var cm = this.codeMirror;
     var cursorPos = cm.getCursor('head');
-    if (cm.indexFromPos(cursorPos)===0) return; // nothing to delete
     var lineAttributes = this.getLineAttributes_(cursorPos.line);
     var listType = lineAttributes[ATTR.LIST_TYPE];
     var indent = lineAttributes[ATTR.LINE_INDENT];
@@ -1076,8 +1075,8 @@ firepad.RichTextCodeMirror = (function () {
     } else if (backspaceAtStartOfLine && indent && indent > 0) {
       this.unindent();
     } else {
-      // refresh attribute from any previous deleteLeft
-      this.updateCurrentAttributes_();
+      if (cm.indexFromPos(cursorPos)<=1) return; // nothing to delete
+      this.updateCurrentAttributes_(); // refresh attribute from any previous deleteLeft
       // disable updateCurrentAttributes in the onNextCursorActivity triggered by deleteH
       this.doNotUpdateCurrentAttributesOnNextCursorActivity=true;
       cm.deleteH(-1, "char");

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -983,7 +983,7 @@ firepad.RichTextCodeMirror = (function () {
       toggleClass(toolbar.underlineBtnElem, 'firepad-btn-highlight', attr.u === true);
       toggleClass(toolbar.strikeBtnElem, 'firepad-btn-highlight', attr.s === true);
     }, 100);
-  }
+  };
 
   // If newState is provided add/remove theClass accordingly, otherwise toggle theClass
   function toggleClass(elem, theClass, newState) {
@@ -992,7 +992,7 @@ firepad.RichTextCodeMirror = (function () {
 
     elem.className = elem.className.replace(matchRegExp, ''); // clear all
     if (add) elem.className += ' ' + theClass;
-  }
+  };
 
   RichTextCodeMirror.prototype.getCurrentLineAttributes_ = function() {
     var cm = this.codeMirror;

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -970,8 +970,8 @@ firepad.RichTextCodeMirror = (function () {
   };
 
   RichTextCodeMirror.prototype.updateToolbarButnsState_ = function() {
+		if (!this.codeMirror || !this.codeMirror.firepad || !this.codeMirror.firepad.toolbar) return;
     var toolbar=this.codeMirror.firepad.toolbar;
-    if (!toolbar) return;
     var attr=this.currentAttributes_;
 
     if (!toolbar.boldBtnElem) { // cache button elements

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -914,7 +914,7 @@ firepad.RichTextCodeMirror = (function () {
   RichTextCodeMirror.prototype.updateCurrentAttributes_ = function() {
     var cm = this.codeMirror;
     var anchor = cm.indexFromPos(cm.getCursor('anchor')), head = cm.indexFromPos(cm.getCursor('head'));
-    var pos = head, c='';
+    var pos = head, c='', nextc;
 
     if (anchor > head) { // backwards selection
       // Advance past any newlines or line sentinels.
@@ -927,7 +927,7 @@ firepad.RichTextCodeMirror = (function () {
         pos++; // since we're going to look at the annotation span to the left to decide what attributes to use.
     } else {
       // look to the left, Back up before any newlines or line sentinels.
-      var nextc=this.getRange(pos, pos+1);
+      nextc=this.getRange(pos, pos+1);
       while(pos > 0) {
         nextc=c;
         c = this.getRange(pos-1, pos);
@@ -938,7 +938,7 @@ firepad.RichTextCodeMirror = (function () {
     }
 
     var spans, lookLeft;
-    var nextc=this.getRange(head, head+1), eol=(nextc==='\n' || nextc===''), sol=(this.getRange(head-1, head)==LineSentinelCharacter);
+    nextc=this.getRange(head, head+1), eol=(nextc==='\n' || nextc===''), sol=(this.getRange(head-1, head)==LineSentinelCharacter);
     if (anchor==head && (head===0 || (sol && !eol))) {
       // special case for head==0 or beginning of a non empty line (and not selection), look right if possible
       spans = this.annotationList_.getAnnotatedSpansForPos(head);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Firebase <support@firebase.com> (https://www.firebase.com/)",
   "contributors": [
     "Michael Lehenbauer <michael@firebase.com>"
-  ],karma-phantomjs-launcher
+  ],
   "homepage": "http://www.firepad.io/",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "karma-coverage": "^0.2.6",
     "karma-failed-reporter": "0.0.2",
     "karma-jasmine": "^0.3.6",
-    "karma-phantomjs-launcher": "~0.2.3",
+    "phantomjs-prebuilt": "2.1.4",
+    "karma-phantomjs-launcher": "~1.0.0",
     "karma-spec-reporter": "0.0.13"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "karma-coverage": "^0.2.6",
     "karma-failed-reporter": "0.0.2",
     "karma-jasmine": "^0.3.6",
-    "karma-phantomjs-launcher": "~1.0.0",
+    "karma-phantomjs-launcher": "~0.2.3",
     "karma-spec-reporter": "0.0.13"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Firebase <support@firebase.com> (https://www.firebase.com/)",
   "contributors": [
     "Michael Lehenbauer <michael@firebase.com>"
-  ],
+  ],karma-phantomjs-launcher
   "homepage": "http://www.firepad.io/",
   "repository": {
     "type": "git",
@@ -55,7 +55,7 @@
     "karma-coverage": "^0.2.6",
     "karma-failed-reporter": "0.0.2",
     "karma-jasmine": "^0.3.6",
-    "karma-phantomjs-launcher": "~0.1.0",
+    "karma-phantomjs-launcher": "~1.0.0",
     "karma-spec-reporter": "0.0.13"
   },
   "scripts": {


### PR DESCRIPTION
This PR includes a few fixes and additions to Firepad attribute changes:
1. Toolbar button state now changes according to the relevant attributes. Included buttons are bold,Italics, Underline & strike. This can be expanded in the future to include all buttons.
2. The original code did not properly handle attribute changes at the end of the line, for example turning bold off and then inserting a newline would still make text on the new line bold. 
   The reason was the original code backs up before the newline which holds this attribute change. The new code backs up to the correct pos.
3. The original code did not properly handle cursor at the beginning of a non empty line - it would copy the attribute s from the left (line before) and not the right (first char). The new code handles this situation correctly.
4. The original code did not properly handle backspace. The new code preserves the attribute of the removed character when pressing backspace.

Demo at: http://plnkr.co/edit/vGtggEc3xQrurST0z6Cl?p=preview
