### PR TITLE
Accept multiple arguments in monaco editor change handler

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,1 @@
+fixed - Fixed an issue in the monaco adapter that could cause errors for certain kinds of edits (#312).

--- a/lib/monaco-adapter.js
+++ b/lib/monaco-adapter.js
@@ -32,8 +32,12 @@ firepad.MonacoAdapter = (function() {
   MonacoAdapter.prototype.onChange = function(change) {
     var pair;
     if (!this.ignoreChanges) {
-      pair = this.operationFromMonacoChange(change);
-      this.trigger.apply(this, ['change'].concat(__slice.call(pair)));
+      var offsetLength = 0
+      change.changes.forEach(function(chan) {
+        pair = this.operationFromMonacoChange(chan, offsetLength);
+        offsetLength = offsetLength + (pair[0].targetLength - pair[0].baseLength)
+        this.trigger.apply(this, ['change'].concat(__slice.call(pair)));
+      }.bind(this))
       return this.grabDocumentState();
     }
   };
@@ -55,14 +59,14 @@ firepad.MonacoAdapter = (function() {
     }, 0);
   };
 
-  MonacoAdapter.prototype.operationFromMonacoChange = function(change) {
-    text = change.changes[0].text;
-    start = this.indexFromPos(change.changes[0].range, 'start');
-    restLength = this.lastDocLines.join(this.monacoModel.getEOL()).length - start;
-    text_ins = change.changes[0].text;
-    rangeLen = change.changes[0].rangeLength;
+  MonacoAdapter.prototype.operationFromMonacoChange = function (change, offsetLength) {
+    text = change.text;
+    start = this.indexFromPos(change.range, 'start');
+    restLength = this.lastDocLines.join(this.monacoModel.getEOL()).length - start + offsetLength;
+    text_ins = change.text;
+    rangeLen = change.rangeLength;
 
-    if (change.changes[0].rangeLength > 0) {
+    if (change.rangeLength > 0) {
       restLength -= rangeLen;
       text = this.lastDocLines.join(this.monacoModel.getEOL())
           .slice(start, start+rangeLen);
@@ -77,9 +81,9 @@ firepad.MonacoAdapter = (function() {
     del_op_ne = new firepad.TextOperation().retain(start)["delete"](text)
         .insert(text_ins).retain(restLength);
 
-    if (change.changes[0].text === "" && rangeLen > 0) {
+    if (change.text === "" && rangeLen > 0) {
       return [delete_op, insert_op];
-    } else if (change.changes[0].text !== "" && rangeLen > 0) {
+    } else if (change.text !== "" && rangeLen > 0) {
       return [del_op_ne, ins_op_ne];
     } else {
       return [insert_op, delete_op];

--- a/lib/monaco-adapter.js
+++ b/lib/monaco-adapter.js
@@ -11,8 +11,8 @@ firepad.MonacoAdapter = (function() {
 
     this.grabDocumentState();
     var changeHandler = this.monaco.onDidChangeModelContent(this.onChange);
-    var didBlurHandler = this.monaco.onDidBlurEditor(this.onBlur);
-    var didFocusHandler = this.monaco.onDidFocusEditor(this.onFocus);
+    var didBlurHandler = this.monaco.onDidBlurEditorWidget(this.onBlur);
+    var didFocusHandler = this.monaco.onDidFocusEditorWidget(this.onFocus);
     var didChangeCursorPositionHandler = this.monaco.onDidChangeCursorPosition(this.onCursorActivity);
 
     this.detach = function() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "firepad",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "package.json"
   ],
   "dependencies": {
-    "firebase": "^3 || ^4",
+    "firebase": "^5.5.4",
     "jsdom": ">3"
   },
   "devDependencies": {
@@ -60,7 +60,7 @@
     "karma-jasmine": "^1.1.2",
     "karma-phantomjs-launcher": "^1.0.4",
     "karma-spec-reporter": "0.0.13",
-    "monaco-editor": "^0.13.1"
+    "monaco-editor": "^0.14.2"
   },
   "scripts": {
     "test": "grunt test",


### PR DESCRIPTION
### Description

This should fix when receiving multiple arguments in the monaco editor change handler. Related issue: https://github.com/FirebaseExtended/firepad/issues/305

### Code sample

To reproduce the error: 
1. enter some characters
2. select few characters
3. type `{` then it will receive an error in the console

