### PR TITLE
Enable comment feature in example/monaco.html

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,1 +1,2 @@
 fixed - Fixed an issue in the monaco adapter that could cause errors for certain kinds of edits (#312).
+feature - Enable comment feature in monaco example by adding default language

--- a/examples/monaco.html
+++ b/examples/monaco.html
@@ -44,7 +44,12 @@
         //// Create Monaco and firepad.
         require.config({ paths: {'vs': './../node_modules/monaco-editor/min/vs'}});
         require(['vs/editor/editor.main'], function() {
-            editor = monaco.editor.create(document.getElementById('firepad'));
+            editor = monaco.editor.create(
+                document.getElementById('firepad'),
+                {
+                    language: 'javascript'
+                }
+            );
             Firepad.fromMonaco(firepadRef, editor);
         });
 


### PR DESCRIPTION
### Description

Enable comment feature in example/monaco.html

Step to use this feature:
1. Type some characters
2. Select the line 
3. Press `Cmd+/`

