### PR TITLE
Fix #322: monaco bug caused by disconnected clients

### DIFF
--- a/lib/monaco-adapter.js
+++ b/lib/monaco-adapter.js
@@ -1,8 +1,8 @@
 firepad.MonacoAdapter = (function () {
-  var __bind = function (fn, me) { 
-    return function () { 
+  var __bind = function (fn, me) {
+    return function () {
       return fn.apply(me, arguments);
-    }; 
+    };
   }
   var __slice = [].slice;
 
@@ -227,6 +227,8 @@ firepad.MonacoAdapter = (function () {
       this.otherCursors[clientId] = this.monaco.deltaDecorations(
         this.otherCursors[clientId], []
       );
+    } else {
+      this.otherCursors[clientId] = [];
     }
     start = this.posFromIndex(cursor.position);
     end = this.posFromIndex(cursor.selectionEnd);


### PR DESCRIPTION
### Description

Fixes #322:

There was an error when a participant disconnected and firepad was calling `monaco.deltaDecorations` with an undefined value (of the participant that just disconnected).

Error: 
```
Uncaught TypeError: Cannot read property 'length' of undefined
    at StandaloneEditor.CodeEditorWidget.deltaDecorations (codeEditorWidget.js:1105)
    at MonacoAdapter.setOtherCursor (firepad.js:3374)
    at OtherClient.updateCursor (firepad.js:2539)
    at cursor (firepad.js:2601)
    at FirebaseAdapter.clazz.trigger (firepad.js:59)
    at childChanged (firepad.js:1706)
    at index.cjs.js:5224
    at exceptionGuard (index.cjs.js:784)
    at EventList.raise (index.cjs.js:11008)
    at EventQueue.raiseQueuedEventsMatchingPredicate_ (index.cjs.js:10948)
    at EventQueue.raiseEventsForChangedPath (index.cjs.js:10927)
    at Repo.onDataUpdate_ (index.cjs.js:14575)
    at PersistentConnection.onDataPush_ (index.cjs.js:13763)
    at PersistentConnection.onDataMessage_ (index.cjs.js:13757)
    at Connection.onDataMessage_ (index.cjs.js:12852)
    at Connection.onPrimaryMessageReceived_ (index.cjs.js:12845)
    at WebSocketConnection.onMessage (index.cjs.js:12724)
    at WebSocketConnection.appendFrame_ (index.cjs.js:12280)
    at WebSocketConnection.handleIncomingFrame (index.cjs.js:12339)
    at WebSocket.mySock.onmessage (index.cjs.js:12214)
```