### PR TITLE
Monaco Adapter: Rewrite from scratch in ES6+

### DIFF
--- a/lib/monaco-adapter.js
+++ b/lib/monaco-adapter.js
@@ -1,301 +1,508 @@
-firepad.MonacoAdapter = (function () {
-  var __bind = function (fn, me) {
-    return function () {
-      return fn.apply(me, arguments);
-    };
+'use strict';
+
+/**
+ * @function getCSS - For Internal Usage Only
+ * @param {String} clazz - CSS Class Name
+ * @param {String} bgColor - Background Color
+ * @param {String} color - Font Color
+ * @returns CSS Style Rules according to Parameters
+ */
+var getCSS = function getCSS(clazz, bgColor, color) {
+  return "." + clazz + " {\n  position: relative;\n" +
+    "background-color: " + bgColor + ";\n" +
+    "border-left: 2px solid " + color + ";\n}";
+};
+
+/**
+ * @function addStyleRule - For Internal Usage Only
+ * @desc Creates style element in document head and pushed all the style rules
+ * @param {String} clazz - CSS Class Name
+ * @param {String} css - CSS Style Rules
+ */
+var addStyleRule = function addStyleRule(clazz, css) {
+  /** House Keeping */
+  if (typeof document === 'undefined' || document === null) {
+    return false;
   }
-  var __slice = [].slice;
 
-  MonacoAdapter.prototype.ignoreChanges = false;
+  /** Add style rules only once */
+  if (this.addedStyleRules.indexOf(clazz) === -1) {
+    var styleElement = document.createElement('style');
+    var styleSheet = document.createTextNode(css);
+    styleElement.appendChild(styleSheet);
+    document.head.appendChild(styleElement);
+    this.addedStyleRules.push(clazz);
+  }
+};
 
+/**
+ * Monaco Adapter
+ * Create Pipe between Firebase and Monaco Text Editor
+ */
+var MonacoAdapter = function () {
+  /**
+   * @constructor MonacoEditor
+   * @param {MonacoEditor} monacoInstance - Editor Instance
+   * @prop {MonacoEditor} monaco - Monaco Instance passed as Parameter
+   * @prop {MonacoITextModel} monacoModel - Data Model of the Monaco Instance
+   * @prop {string[]} lastDocLines - Text for all Lines in the Editor
+   * @prop {MonacoSelection} lastCursorRange - Primary Selection of the Editor
+   * @prop {function} onChange - Change Event Handler bound Local Object
+   * @prop {function} onBlur - Blur Event Handler bound Local Object
+   * @prop {function} onFocus - Focus Event Handler bound Local Object
+   * @prop {function} onCursorActivity - Cursor Activity Handler bound Local Object
+   * @prop {Boolean} ignoreChanges - Should Avoid OnChange Event Handling
+   * @prop {MonacoIDisposable} changeHandler - Event Handler for Model Content Change
+   * @prop {MonacoIDisposable} didBlurHandler - Event Handler for Focus Lost on Editor Text/Widget
+   * @prop {MonacoIDisposable} didFocusHandler - Event Handler for Focus Gain on Editor Text/Widget
+   * @prop {MonacoIDisposable} didChangeCursorPositionHandler - Event Handler for Cursor Position Change
+   */
   function MonacoAdapter(monacoInstance) {
-    this.onCursorActivity = __bind(this.onCursorActivity, this);
-    this.onFocus = __bind(this.onFocus, this);
-    this.onBlur = __bind(this.onBlur, this);
-    this.onChange = __bind(this.onChange, this);
+    /** House Keeping */
+    if (monacoInstance !== null && typeof global !== 'undefined' && global.monaco
+      && !monacoInstance instanceof global.monaco) {
+
+      throw new Error('MonacoAdapter: Incorrect Parameter Recieved in constructor, '
+        + 'expected valid Monaco Instance');
+    }
+
+    /** Monaco Member Variables */
     this.monaco = monacoInstance;
     this.monacoModel = this.monaco.getModel();
+    this.lastDocLines = this.monacoModel.getLinesContent();
+    this.lastCursorRange = this.monaco.getSelection();
 
-    this.grabDocumentState();
-    var changeHandler = this.monaco.onDidChangeModelContent(this.onChange);
-    var didBlurHandler = this.monaco.onDidBlurEditorWidget(this.onBlur);
-    var didFocusHandler = this.monaco.onDidFocusEditorWidget(this.onFocus);
-    var didChangeCursorPositionHandler = this.monaco.onDidChangeCursorPosition(this.onCursorActivity);
+    /** Monaco Editor Configurations */
+    this.callbacks = {};
+    this.otherCursors = [];
+    this.addedStyleRules = [];
+    this.ignoreChanges = false;
 
-    this.detach = function () {
-      changeHandler.dispose();
-      didBlurHandler.dispose();
-      didFocusHandler.dispose();
-      didChangeCursorPositionHandler.dispose();
-    };
+    /** Adapter Callback Functions */
+    this.onChange = this.onChange.bind(this);
+    this.onBlur = this.onBlur.bind(this);
+    this.onFocus = this.onFocus.bind(this);
+    this.onCursorActivity = this.onCursorActivity.bind(this);
+
+    /** Editor Callback Handler */
+    this.changeHandler = this.monaco.onDidChangeModelContent(this.onChange);
+    this.didBlurHandler = this.monaco.onDidBlurEditorWidget(this.onBlur);
+    this.didFocusHandler = this.monaco.onDidFocusEditorWidget(this.onFocus);
+    this.didChangeCursorPositionHandler = this.monaco.onDidChangeCursorPosition(this.onCursorActivity);
   }
 
-  MonacoAdapter.prototype.grabDocumentState = function () {
-    this.lastDocLines = this.monacoModel.getLinesContent();
-    var range = this.monaco.getSelection();
-    return this.lastCursorRange = range;
+  /**
+   * @method detach - Clears an Instance of Editor Adapter
+   */
+  MonacoAdapter.prototype.detach = function detach() {
+    this.changeHandler.dispose();
+    this.didBlurHandler.dispose();
+    this.didFocusHandler.dispose();
+    this.didChangeCursorPositionHandler.dispose();
   };
 
-  MonacoAdapter.prototype.onChange = function (change) {
-    var pair;
-    if (!this.ignoreChanges) {
-      var content = this.lastDocLines.join(this.monacoModel.getEOL());
-      var offsetLength = 0;
-      change.changes.reverse().forEach(function(chan) {
-        pair = this.operationFromMonacoChange(chan, content, offsetLength);
-        offsetLength = offsetLength + (pair[0].targetLength - pair[0].baseLength);
-        this.trigger.apply(this, ['change'].concat(__slice.call(pair)));
-      }.bind(this))
-      return this.grabDocumentState();
-    }
-  };
+  /**
+   * @method getCursor - Get current cursor position
+   * @returns Firepad Cursor object
+   */
+  MonacoAdapter.prototype.getCursor = function getCursor() {
+    var selection = this.monaco.getSelection();
 
-  MonacoAdapter.prototype.onBlur = function () {
-    if (this.monaco.getSelection().isEmpty()) {
-      return this.trigger('blur');
-    }
-  };
-
-  MonacoAdapter.prototype.onFocus = function () {
-    return this.trigger('focus');
-  };
-
-  MonacoAdapter.prototype.onCursorActivity = function () {
-    var _this = this;
-    return setTimeout(function () {
-      return _this.trigger('cursorActivity');
-    }, 0);
-  };
-
-  MonacoAdapter.prototype.operationFromMonacoChange = function (change, content, offsetLength) {
-    text = change.text;
-    start = change.rangeOffset + offsetLength;
-
-    restLength = content.length - start + offsetLength;
-    text_ins = change.text;
-    rangeLength = change.rangeLength;
-
-    if (text.length === 0 && rangeLength > 0) {
-      // Delete operation.
-      var replacedText = content.slice(start, start + rangeLength);
-
-      var delete_op = new firepad.TextOperation()
-          .retain(start)
-          .delete(rangeLength)
-          .retain(restLength - rangeLength);
-
-      var inverse_op = new firepad.TextOperation()
-          .retain(start)
-          .insert(replacedText)
-          .retain(restLength - rangeLength);
-
-      return [delete_op, inverse_op];
-    } else if (text.length > 0 && rangeLength > 0) {
-      // Replace operation.
-      var replacedText = content.slice(start, start + rangeLength);
-
-      var replace_op = new firepad.TextOperation()
-          .retain(start)
-          .delete(rangeLength)
-          .insert(text)
-          .retain(restLength - rangeLength);
-
-      var inverse_op = new firepad.TextOperation()
-          .retain(start)
-          .delete(text.length)
-          .insert(replacedText)
-          .retain(restLength - rangeLength);
-
-      return [replace_op, inverse_op];
-    } else {
-      // Insert operation.
-
-      var insert_op = new firepad.TextOperation()
-          .retain(start)
-          .insert(text)
-          .retain(restLength);
-
-      var inverse_op = new firepad.TextOperation()
-          .retain(start)
-          .delete(text)
-          .retain(restLength);
-
-      return [insert_op, inverse_op];
-    }
-  };
-
-  MonacoAdapter.prototype.applyOperationToMonaco = function (operation) {
-    var from, index, op, to, _i, _len, _ref, id, ops, range;
-    index = 0;
-    _ref = operation.ops;
-    for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-      op = _ref[_i];
-      if (op.isRetain()) {
-        index += op.chars;
-      } else if (op.isInsert()) {
-        var pos = this.monacoModel.getPositionAt(index);
-        range = new monaco.Range(
-          pos.lineNumber,
-          pos.column,
-          pos.lineNumber,
-          pos.column
-        );
-        id = { major: 1, minor: 1 };
-        ops = {
-          identifier: id, range: range, text: op.text,
-          forceMoveMarkers: true
-        };
-        this.monaco.executeEdits("my-source", [ops]);
-        index += op.text.length;
-      } else if (op.isDelete()) {
-        from = this.monacoModel.getPositionAt(index);
-        to = this.monacoModel.getPositionAt(index + op.chars);
-
-        range = new monaco.Range(from.lineNumber, from.column, to.lineNumber, to.column);
-        id = { major: 1, minor: 2 };
-        ops = {
-          identifier: id, range: range, text: "",
-          forceMoveMarkers: true
-        };
-        this.monaco.executeEdits("my-source", [ops]);
-      }
-    }
-    this.grabDocumentState();
-  };
-
-  MonacoAdapter.prototype.getValue = function () {
-    return this.monacoModel.getValue();
-  };
-
-  MonacoAdapter.prototype.getCursor = function () {
-    var e, e2, end, start, _ref, _ref1;
-    try {
-      selection = this.monaco.getSelection();
-
-      if (typeof selection === 'undefined' || selection === null) {
-        selection = this.lastCursorRange;
-      }
-
-      start = this.monacoModel.getOffsetAt(selection.getStartPosition());
-      end = this.monacoModel.getOffsetAt(selection.getEndPosition());
-    } catch (_error) {
-      e2 = _error;
-      console.log("Couldn't figure out the cursor range:",
-        e2, "-- setting it to 0:0.");
-      _ref = [0, 0], start = _ref[0], end = _ref[1];
+    /** Fallback to last cursor change */
+    if (typeof selection === 'undefined' || selection === null) {
+      selection = this.lastCursorRange;
     }
 
+    /** Obtain selection indexes */
+    var startPos = selection.getStartPosition();
+    var endPos = selection.getEndPosition();
+    var start = this.monacoModel.getOffsetAt(startPos);
+    var end = this.monacoModel.getOffsetAt(endPos);
+
+    /** If Selection is Inversed */
     if (start > end) {
-      _ref1 = [end, start], start = _ref1[0], end = _ref1[1];
+      var _ref = [end, start];
+      start = _ref[0];
+      end = _ref[1];
     }
+
+    /** Return cursor position */
     return new firepad.Cursor(start, end);
   };
 
-  MonacoAdapter.prototype.setCursor = function (cursor) {
-    var end, start, _ref;
-    start = this.monacoModel.getPositionAt(cursor.position);
-    end = this.monacoModel.getPositionAt(cursor.selectionEnd);
-    if (cursor.position > cursor.selectionEnd) {
-      _ref = [end, start], start = _ref[0], end = _ref[1];
+  /**
+   * @method setCursor - Set Selection on Monaco Editor Instance
+   * @param {Object} cursor - Cursor Position (start and end)
+   * @param {Number} cursor.position - Starting Position of the Cursor
+   * @param {Number} cursor.selectionEnd - Ending Position of the Cursor
+   */
+  MonacoAdapter.prototype.setCursor = function setCursor(cursor) {
+    var position = cursor.position;
+    var selectionEnd = cursor.selectionEnd;
+    var start = this.monacoModel.getPositionAt(position);
+    var end = this.monacoModel.getPositionAt(selectionEnd);
+
+    /** If selection is inversed */
+    if (position > selectionEnd) {
+      var _ref = [end, start];
+      start = _ref[0];
+      end = _ref[1];
     }
-    return this.monaco.setSelection(
-      new monaco.Range(start.lineNumber, start.column, end.lineNumber, end.column)
+
+    /** Create Selection in the Editor */
+    this.monaco.setSelection(
+      new monaco.Range(
+        start.lineNumber, start.column,
+        end.lineNumber, end.column
+      )
     );
   };
 
-  MonacoAdapter.prototype.setOtherCursor = function (cursor, color, clientId) {
-    if (this.otherCursors == null) {
-      this.otherCursors = {};
-      this.otherCursors[clientId] = [];
+  /**
+   * @method setOtherCursor - Set Remote Selection on Monaco Editor
+   * @param {Number} cursor.position - Starting Position of the Selection
+   * @param {Number} cursor.selectionEnd - Ending Position of the Selection
+   * @param {String} color - Hex Color codes for Styling
+   * @param {any} clientID - ID number of the Remote Client
+   */
+  MonacoAdapter.prototype.setOtherCursor = function setOtherCursor(cursor, color, clientID) {
+    /** House Keeping */
+    if (typeof cursor !== 'object' || typeof cursor.position !== 'number'
+      || typeof cursor.selectionEnd !== 'number') {
+
+      return false;
     }
-    if (this.otherCursors[clientId]) {
-      this.otherCursors[clientId] = this.monaco.deltaDecorations(
-        this.otherCursors[clientId], []
-      );
-    } else {
-      this.otherCursors[clientId] = [];
+
+    if (typeof color !== 'string' || !color.match(/^#[a-fA-F0-9]{3,6}$/)) {
+      return false;
     }
-    start = this.monacoModel.getPositionAt(cursor.position);
-    end = this.monacoModel.getPositionAt(cursor.selectionEnd);
-    clazz = "other-client-selection-" + (color.replace('#', ''));
-    if (start < 0 || end < 0 || start > end) {
-      return;
+
+    /** Extract Positions */
+    var position = cursor.position;
+    var selectionEnd = cursor.selectionEnd;
+
+    if (position < 0 || selectionEnd < 0) {
+      return false;
     }
-    justCursor = cursor.position === cursor.selectionEnd;
-    if (justCursor) {
-      // show cursor
+
+    /** Fetch Client Cursor Information */
+    var otherCursor = this.otherCursors.find(function (cursor) {
+      return cursor.clientID === clientID;
+    });
+
+    /** Initialize empty array, if client does not exist */
+    if (!otherCursor) {
+      otherCursor = {
+        clientID: clientID,
+        decoration: []
+      };
+      this.otherCursors.push(otherCursor);
+    }
+
+    /** Remove Earlier Decorations, if any, or initialize empty decor */
+    otherCursor.decoration = this.monaco.deltaDecorations(otherCursor.decoration, []);
+    var clazz = "other-client-selection-" + color.replace('#', '');
+    var css, ret;
+
+    if (position === selectionEnd) {
+      /** Show only cursor */
       clazz = clazz.replace('selection', 'cursor');
+
+      /** Generate Style rules and add them to document */
+      css = getCSS(clazz, 'transparent', color);
+      ret = addStyleRule.call(this, clazz, css);
+    } else {
+      /** Generate Style rules and add them to document */
+      css = getCSS(clazz, color, color);
+      ret = addStyleRule.call(this, clazz, css);
     }
-    css = "." + clazz + " {\n  position: relative;\n" +
-      "background-color: " + (justCursor ? 'transparent' : color) + ";\n" +
-      "border-left: 2px solid " + color + ";\n}";
-    this.addStyleRule(css);
-    this.otherCursors[clientId] = this.monaco.deltaDecorations(
-      this.otherCursors[clientId], [{
-        range: new monaco.Range(
-          start.lineNumber, start.column, end.lineNumber, end.column),
-        options: { className: clazz }
-      },
+
+    /** Return if failed to add css */
+    if (ret == false) {
+      console.log("Monaco Adapter: Failed to add some css style.\n"
+      + "Please make sure you're running on supported environment.");
+    }
+
+    /** Get co-ordinate position in Editor */
+    var start = this.monacoModel.getPositionAt(position);
+    var end = this.monacoModel.getPositionAt(selectionEnd);
+
+    /** Selection is inversed */
+    if (position > selectionEnd) {
+      var _ref = [end, start];
+      start = _ref[0];
+      end = _ref[1];
+    }
+
+    /** Add decoration to the Editor */
+    otherCursor.decoration = this.monaco.deltaDecorations(otherCursor.decoration,
+      [
+        {
+          range: new monaco.Range(
+            start.lineNumber, start.column,
+            end.lineNumber, end.column
+          ),
+          options: {
+            className: clazz
+          }
+        }
       ]
     );
-    _this = this;
+
+    /** Clear cursor method */
+    var _this = this;
     return {
-      clear: function () {
-        return _this.monaco.deltaDecorations(
-          _this.otherCursors[clientId], []);
+      clear: function clear() {
+        otherCursor.decoration = _this.monaco.deltaDecorations(otherCursor.decoration, []);
       }
     };
   };
 
-  MonacoAdapter.prototype.addStyleRule = function (css) {
-    var styleElement;
-    if (typeof document === "undefined" || document === null) {
+  /**
+   * @method registerCallbacks - Assign callback functions to internal property
+   * @param {function[]} callbacks - Set of callback functions
+   */
+  MonacoAdapter.prototype.registerCallbacks = function registerCallbacks(callbacks) {
+    this.callbacks = Object.assign({}, this.callbacks, callbacks);
+  };
+
+  /**
+   * @method registerUndo
+   * @param {function} callback - Callback Handler for Undo Event
+   */
+  MonacoAdapter.prototype.registerUndo = function registerUndo(callback) {
+    if (typeof callback === 'function') {
+      this.callbacks.undo = callback;
+    } else {
+      throw new Error('MonacoAdapter: registerUndo method expects a '
+        + 'callback function in parameter');
+    }
+  };
+
+  /**
+   * @method registerRedo
+   * @param {function} callback - Callback Handler for Redo Event
+   */
+  MonacoAdapter.prototype.registerRedo = function registerRedo(callback) {
+    if (typeof callback === 'function') {
+      this.callbacks.redo = callback;
+    } else {
+      throw new Error('MonacoAdapter: registerRedo method expects a '
+        + 'callback function in parameter');
+    }
+  };
+
+  /**
+   * @method operationFromMonacoChanges - Convert Monaco Changes to OT.js Ops
+   * @param {Object} change - Change in Editor
+   * @param {string} content - Last Editor Content
+   * @param {Number} offset - Offset between changes of same event
+   * @returns Pair of Operation and Inverse
+   * Note: OT.js Operation expects the cursor to be at the end of content
+   */
+  MonacoAdapter.prototype.operationFromMonacoChanges = function operationFromMonacoChanges(change, content, offset) {
+    /** Change Informations */
+    var text = change.text;
+    var rangeLength = change.rangeLength;
+    var rangeOffset = change.rangeOffset + offset;
+
+    /** Additional SEEK distance */
+    var restLength = content.length + offset - rangeOffset;
+
+    /** Declare OT.js Operation Variables */
+    var change_op, inverse_op, replaced_text;
+
+    if (text.length === 0 && rangeLength > 0) {
+      /** Delete Operation */
+      replaced_text = content.slice(rangeOffset, rangeOffset + rangeLength);
+
+      change_op = new firepad.TextOperation()
+        .retain(rangeOffset)
+        .delete(rangeLength)
+        .retain(restLength - rangeLength);
+
+      inverse_op = new firepad.TextOperation()
+        .retain(rangeOffset)
+        .insert(replaced_text)
+        .retain(restLength - rangeLength);
+    } else if (text.length > 0 && rangeLength > 0) {
+      /** Replace Operation */
+      replaced_text = content.slice(rangeOffset, rangeOffset + rangeLength);
+
+      change_op = new firepad.TextOperation()
+        .retain(rangeOffset)
+        .delete(rangeLength)
+        .insert(text)
+        .retain(restLength - rangeLength);
+
+      inverse_op = new firepad.TextOperation()
+        .retain(rangeOffset)
+        .delete(text.length)
+        .insert(replaced_text)
+        .retain(restLength - rangeLength);
+    } else {
+      /** Insert Operation */
+      change_op = new firepad.TextOperation()
+        .retain(rangeOffset)
+        .insert(text)
+        .retain(restLength);
+
+      inverse_op = new firepad.TextOperation()
+        .retain(rangeOffset)
+        .delete(text)
+        .retain(restLength);
+    }
+
+    return [ change_op, inverse_op ];
+  };
+
+  /**
+   * @method onChange - OnChange Event Handler
+   * @param {Object} event - OnChange Event Delegate
+   */
+  MonacoAdapter.prototype.onChange = function onChange(event) {
+    var _this = this;
+
+    if (!this.ignoreChanges) {
+      var content = this.lastDocLines.join(this.monacoModel.getEOL());
+      var offset = 0;
+
+      /** If no change information recieved */
+      if (!event.changes) {
+        var op = new firepad.TextOperation().retain(content.length);
+        this.trigger('change', op, op);
+      }
+
+      /** Reverse iterate all changes */
+      event.changes.reverse().forEach(function (change) {
+        var pair = _this.operationFromMonacoChanges(change, content, offset);
+        offset += pair[0].targetLength - pair[0].baseLength;
+
+        _this.trigger.apply(_this, ['change'].concat(pair));
+      });
+
+      /** Update Editor Content */
+      this.lastDocLines = this.monacoModel.getLinesContent();
+    }
+  };
+
+  /**
+   * @method trigger - Event Handler
+   * @param {string} event - Event name
+   * @param  {...any} args - Callback arguments
+   */
+  MonacoAdapter.prototype.trigger = function trigger(event) {
+    if (!this.callbacks.hasOwnProperty(event)) {
       return;
     }
-    if (!this.addedStyleRules) {
-      this.addedStyleRules = {};
-      styleElement = document.createElement('style');
-      document.documentElement.getElementsByTagName('head')[0]
-        .appendChild(styleElement);
-      this.addedStyleSheet = styleElement.sheet;
-    }
-    if (this.addedStyleRules[css]) {
+
+    var action = this.callbacks[event];
+
+    if (! typeof action === 'function') {
       return;
     }
-    this.addedStyleRules[css] = true;
-    return this.addedStyleSheet.insertRule(css, 0);
+
+    var args = [];
+
+    if (arguments.length > 1) {
+      for (var i = 1; i < arguments.length; i++) {
+        args.push(arguments[i]);
+      }
+    }
+
+    action.apply(null, args);
   };
 
-  MonacoAdapter.prototype.registerCallbacks = function (callbacks) {
-    this.callbacks = callbacks;
+  /**
+   * @method onBlur - Blur event handler
+   */
+  MonacoAdapter.prototype.onBlur = function onBlur() {
+    if (this.monaco.getSelection().isEmpty()) {
+      this.trigger('blur');
+    }
   };
 
-  MonacoAdapter.prototype.trigger = function (event) {
-    var args = Array.prototype.slice.call(arguments, 1);
-    var action = this.callbacks && this.callbacks[event];
-    if (action) { action.apply(this, args); }
+  /**
+   * @method onFocus - Focus event handler
+   */
+  MonacoAdapter.prototype.onFocus = function onFocus() {
+    this.trigger('focus');
   };
 
-  MonacoAdapter.prototype.applyOperation = function (operation) {
+  /**
+   * @method onCursorActivity - CursorActivity event handler
+   */
+  MonacoAdapter.prototype.onCursorActivity = function onCursorActivity() {
+    var _this = this;
+
+    setTimeout(function () {
+      return _this.trigger('cursorActivity');
+    }, 1);
+  };
+
+  /**
+   * @method applyOperation
+   * @param {Operation} operation - OT.js Operation Object
+   */
+  MonacoAdapter.prototype.applyOperation = function applyOperation(operation) {
     if (!operation.isNoop()) {
       this.ignoreChanges = true;
     }
-    this.applyOperationToMonaco(operation);
-    return this.ignoreChanges = false;
+
+    /** Get Operations List */
+    var opsList = operation.ops;
+    var index = 0;
+
+    var _this = this;
+    opsList.forEach(function (op) {
+      /** Retain Operation */
+      if (op.isRetain()) {
+        index += op.chars;
+      } else if (op.isInsert()) {
+        /** Insert Operation */
+        var pos = _this.monacoModel.getPositionAt(index);
+
+        _this.monaco.executeEdits('my-source', [{
+          range: new monaco.Range(
+            pos.lineNumber, pos.column,
+            pos.lineNumber, pos.column
+          ),
+          text: op.text,
+          forceMoveMarkers: true
+        }]);
+
+        index += op.text.length;
+      } else if (op.isDelete()) {
+        /** Delete Operation */
+        var from = _this.monacoModel.getPositionAt(index);
+        var to = _this.monacoModel.getPositionAt(index + op.chars);
+
+        _this.monaco.executeEdits('my-source', [{
+          range: new monaco.Range(
+            from.lineNumber, from.column,
+            to.lineNumber, to.column
+          ),
+          text: '',
+          forceMoveMarkers: true
+        }]);
+      }
+    });
+
+    /** Update Editor Content and Reset Config */
+    this.lastDocLines = this.monacoModel.getLinesContent();
+    this.ignoreChanges = false;
   };
 
-  MonacoAdapter.prototype.registerUndo = function (undoFn) {
-    return this.monacoModel.undo = undoFn;
-  };
-
-  MonacoAdapter.prototype.registerRedo = function (redoFn) {
-    return this.monacoModel.redo = redoFn;
-  };
-
-  MonacoAdapter.prototype.invertOperation = function (operation) {
-    return operation.invert(this.getValue());
+  /**
+   * @method invertOperation
+   * @param {Operation} operation - OT.js Operation Object
+   */
+  MonacoAdapter.prototype.invertOperation = function invertOperation(operation) {
+    operation.invert(this.getValue());
   };
 
   return MonacoAdapter;
+}(); /** Export Module */
 
-})();
+
+firepad.MonacoAdapter = MonacoAdapter;

--- a/test/specs/monaco-ops.spec.js
+++ b/test/specs/monaco-ops.spec.js
@@ -1,7 +1,5 @@
 /** Monaco Adapter Unit Tests */
 describe('Monaco Operations Test', function () {
-    var MonacoAdapter = firepad.MonacoAdapter;
-
     /** Editor Content */
     var editorContent =
 `module Conway {
@@ -33,7 +31,8 @@ describe('Monaco Operations Test', function () {
     ];
 
     it('should convert Monaco Editor changes to Text Operation', function () {
-        var operationFromMonacoChange = MonacoAdapter.prototype.operationFromMonacoChange;
+        var MonacoAdapter = firepad.MonacoAdapter;
+        var operationFromMonacoChange = MonacoAdapter.prototype.operationFromMonacoChanges;
 
         let offset = 0;
         operations.reverse().forEach((operation, index) => {
@@ -53,4 +52,3 @@ describe('Monaco Operations Test', function () {
         });
     });
 });
-


### PR DESCRIPTION
Created only those APIs that are been called either by
Firepad or EditorClient.

Syncing between editors and cursors.

Updated package-lock, found 7 vulnerability with breaking
change update

Removed depenencies and function prototypes created while
transpiling from Coffescript code for Ace. Rewritten specific to
Monaco Editor and it's API standards.

Add Build task to convert ES6+ codes into ES5 using Babel.

Add Testcases to verify changes from Monaco editor onChange
event handler to OT.js Text Operations.

Ref: #324 
Closes: #313 

Signed-off-by: Progyan Bhattacharya <Progyan@hackerrank.com>