### PR TITLE
Fix incorrect offset handling in Monaco adapter.

### DIFF
--- a/lib/monaco-adapter.js
+++ b/lib/monaco-adapter.js
@@ -160,7 +160,7 @@ firepad.MonacoAdapter = (function () {
         this.monaco.executeEdits("my-source", [ops]);
       }
     }
-    return this.grabDocumentState();
+    this.grabDocumentState();
   };
 
   MonacoAdapter.prototype.getValue = function () {

--- a/lib/monaco-adapter.js
+++ b/lib/monaco-adapter.js
@@ -81,7 +81,7 @@ firepad.MonacoAdapter = (function () {
 
       var delete_op = new firepad.TextOperation()
           .retain(start)
-          ['delete'](rangeLength)
+          .delete(rangeLength)
           .retain(restLength - rangeLength);
 
       var inverse_op = new firepad.TextOperation()
@@ -96,13 +96,13 @@ firepad.MonacoAdapter = (function () {
 
       var replace_op = new firepad.TextOperation()
           .retain(start)
-          ['delete'](rangeLength)
+          .delete(rangeLength)
           .insert(text)
           .retain(restLength - rangeLength);
 
       var inverse_op = new firepad.TextOperation()
           .retain(start)
-          ['delete'](text.length)
+          .delete(text.length)
           .insert(replacedText)
           .retain(restLength - rangeLength);
 

--- a/lib/monaco-adapter.js
+++ b/lib/monaco-adapter.js
@@ -39,10 +39,11 @@ firepad.MonacoAdapter = (function () {
   MonacoAdapter.prototype.onChange = function (change) {
     var pair;
     if (!this.ignoreChanges) {
-      var offsetLength = 0
-      change.changes.forEach(function(chan) {
-        pair = this.operationFromMonacoChange(chan, offsetLength);
-        offsetLength = offsetLength + (pair[0].targetLength - pair[0].baseLength)
+      var content = this.lastDocLines.join(this.monacoModel.getEOL());
+      var offsetLength = 0;
+      change.changes.reverse().forEach(function(chan) {
+        pair = this.operationFromMonacoChange(chan, content, offsetLength);
+        offsetLength = offsetLength + (pair[0].targetLength - pair[0].baseLength);
         this.trigger.apply(this, ['change'].concat(__slice.call(pair)));
       }.bind(this))
       return this.grabDocumentState();
@@ -66,34 +67,60 @@ firepad.MonacoAdapter = (function () {
     }, 0);
   };
 
-  MonacoAdapter.prototype.operationFromMonacoChange = function (change, offsetLength) {
+  MonacoAdapter.prototype.operationFromMonacoChange = function (change, content, offsetLength) {
     text = change.text;
-    start = this.indexFromPos(change.range, 'start');
-    restLength = this.lastDocLines.join(this.monacoModel.getEOL()).length - start + offsetLength;
+    start = change.rangeOffset + offsetLength;
+
+    restLength = content.length - start + offsetLength;
     text_ins = change.text;
-    rangeLen = change.rangeLength;
+    rangeLength = change.rangeLength;
 
-    if (change.rangeLength > 0) {
-      restLength -= rangeLen;
-      text = this.lastDocLines.join(this.monacoModel.getEOL())
-        .slice(start, start + rangeLen);
-    }
+    if (text.length === 0 && rangeLength > 0) {
+      // Delete operation.
+      var replacedText = content.slice(start, start + rangeLength);
 
-    insert_op = new firepad.TextOperation().retain(start).insert(text)
-      .retain(restLength);
-    delete_op = new firepad.TextOperation().retain(start)["delete"](text)
-      .retain(restLength);
-    ins_op_ne = new firepad.TextOperation().retain(start)["delete"](text_ins)
-      .insert(text).retain(restLength);
-    del_op_ne = new firepad.TextOperation().retain(start)["delete"](text)
-      .insert(text_ins).retain(restLength);
+      var delete_op = new firepad.TextOperation()
+          .retain(start)
+          ['delete'](rangeLength)
+          .retain(restLength - rangeLength);
 
-    if (change.text === "" && rangeLen > 0) {
-      return [delete_op, insert_op];
-    } else if (change.text !== "" && rangeLen > 0) {
-      return [del_op_ne, ins_op_ne];
+      var inverse_op = new firepad.TextOperation()
+          .retain(start)
+          .insert(replacedText)
+          .retain(restLength - rangeLength);
+
+      return [delete_op, inverse_op];
+    } else if (text.length > 0 && rangeLength > 0) {
+      // Replace operation.
+      var replacedText = content.slice(start, start + rangeLength);
+
+      var replace_op = new firepad.TextOperation()
+          .retain(start)
+          ['delete'](rangeLength)
+          .insert(text)
+          .retain(restLength - rangeLength);
+
+      var inverse_op = new firepad.TextOperation()
+          .retain(start)
+          ['delete'](text.length)
+          .insert(replacedText)
+          .retain(restLength - rangeLength);
+
+      return [replace_op, inverse_op];
     } else {
-      return [insert_op, delete_op];
+      // Insert operation.
+
+      var insert_op = new firepad.TextOperation()
+          .retain(start)
+          .insert(text)
+          .retain(restLength);
+
+      var inverse_op = new firepad.TextOperation()
+          .retain(start)
+          .delete(text)
+          .retain(restLength);
+
+      return [insert_op, inverse_op];
     }
   };
 
@@ -106,11 +133,12 @@ firepad.MonacoAdapter = (function () {
       if (op.isRetain()) {
         index += op.chars;
       } else if (op.isInsert()) {
+        var pos = this.monacoModel.getPositionAt(index);
         range = new monaco.Range(
-          this.posFromIndex(index).row,
-          this.posFromIndex(index).column,
-          this.posFromIndex(index).row,
-          this.posFromIndex(index).column
+          pos.lineNumber,
+          pos.column,
+          pos.lineNumber,
+          pos.column
         );
         id = { major: 1, minor: 1 };
         ops = {
@@ -120,11 +148,10 @@ firepad.MonacoAdapter = (function () {
         this.monaco.executeEdits("my-source", [ops]);
         index += op.text.length;
       } else if (op.isDelete()) {
-        content = this.monacoModel.getLinesContent();
-        from = this.posFromIndex(index, content);
-        to = this.posFromIndex(index + op.chars, content);
+        from = this.monacoModel.getPositionAt(index);
+        to = this.monacoModel.getPositionAt(index + op.chars);
 
-        range = new monaco.Range(from.row, from.column, to.row, to.column);
+        range = new monaco.Range(from.lineNumber, from.column, to.lineNumber, to.column);
         id = { major: 1, minor: 2 };
         ops = {
           identifier: id, range: range, text: "",
@@ -136,48 +163,6 @@ firepad.MonacoAdapter = (function () {
     return this.grabDocumentState();
   };
 
-  // Index in monaco starts from 1
-  MonacoAdapter.prototype.posFromIndex = function (index, content) {
-    var line, row, _i, _len, _ref;
-    if (content == null) {
-      _ref = this.lastDocLines;
-    }
-    else {
-      _ref = content;
-    }
-    for (row = _i = 0, _len = _ref.length; _i < _len; row = ++_i) {
-      line = _ref[row];
-      if (index <= line.length) {
-        break;
-      }
-      index -= line.length + this.monacoModel.getEOL().length;
-    }
-    return {
-      row: row + 1,
-      column: index + 1
-    };
-  };
-
-  // Index in monaco start from 1
-  MonacoAdapter.prototype.indexFromPos = function (range, upto, lines) {
-    var index;
-    if (lines == null) {
-      lines = this.lastDocLines;
-    }
-    index = 0;
-    if (upto === 'start') {
-      for (row = 1; row < range.startLineNumber; row++) {
-        index += lines[row - 1].length + this.monacoModel.getEOL().length;
-      }
-      return index + range.startColumn - 1;
-    } else {
-      for (row = 1; row < range.endLineNumber; row++) {
-        index += lines[row - 1].length + this.monacoModel.getEOL().length;
-      }
-      return index + range.endColumn - 1;
-    }
-  };
-
   MonacoAdapter.prototype.getValue = function () {
     return this.monacoModel.getValue();
   };
@@ -186,20 +171,20 @@ firepad.MonacoAdapter = (function () {
     var e, e2, end, start, _ref, _ref1;
     try {
       selection = this.monaco.getSelection();
-      start = this.indexFromPos(selection, 'start', this.lastDocLines);
-      end = this.indexFromPos(selection, 'end', this.lastDocLines);
-    } catch (_error) {
-      e = _error;
-      try {
-        start = this.indexFromPos(this.lastCursorRange, 'start');
-        end = this.indexFromPos(this.lastCursorRange, 'end');
-      } catch (_error) {
-        e2 = _error;
-        console.log("Couldn't figure out the cursor range:",
-          e2, "-- setting it to 0:0.");
-        _ref = [0, 0], start = _ref[0], end = _ref[1];
+
+      if (typeof selection === 'undefined' || selection === null) {
+        selection = this.lastCursorRange;
       }
+
+      start = this.monacoModel.getOffsetAt(selection.getStartPosition());
+      end = this.monacoModel.getOffsetAt(selection.getEndPosition());
+    } catch (_error) {
+      e2 = _error;
+      console.log("Couldn't figure out the cursor range:",
+        e2, "-- setting it to 0:0.");
+      _ref = [0, 0], start = _ref[0], end = _ref[1];
     }
+
     if (start > end) {
       _ref1 = [end, start], start = _ref1[0], end = _ref1[1];
     }
@@ -208,13 +193,13 @@ firepad.MonacoAdapter = (function () {
 
   MonacoAdapter.prototype.setCursor = function (cursor) {
     var end, start, _ref;
-    start = this.posFromIndex(cursor.position);
-    end = this.posFromIndex(cursor.selectionEnd);
+    start = this.monacoModel.getPositionAt(cursor.position);
+    end = this.monacoModel.getPositionAt(cursor.selectionEnd);
     if (cursor.position > cursor.selectionEnd) {
       _ref = [end, start], start = _ref[0], end = _ref[1];
     }
     return this.monaco.setSelection(
-      new monaco.Range(start.row, start.column, end.row, end.column)
+      new monaco.Range(start.lineNumber, start.column, end.lineNumber, end.column)
     );
   };
 
@@ -230,8 +215,8 @@ firepad.MonacoAdapter = (function () {
     } else {
       this.otherCursors[clientId] = [];
     }
-    start = this.posFromIndex(cursor.position);
-    end = this.posFromIndex(cursor.selectionEnd);
+    start = this.monacoModel.getPositionAt(cursor.position);
+    end = this.monacoModel.getPositionAt(cursor.selectionEnd);
     clazz = "other-client-selection-" + (color.replace('#', ''));
     if (start < 0 || end < 0 || start > end) {
       return;
@@ -248,7 +233,7 @@ firepad.MonacoAdapter = (function () {
     this.otherCursors[clientId] = this.monaco.deltaDecorations(
       this.otherCursors[clientId], [{
         range: new monaco.Range(
-          start.row, start.column, end.row, end.column),
+          start.lineNumber, start.column, end.lineNumber, end.column),
         options: { className: clazz }
       },
       ]

--- a/test/index.html
+++ b/test/index.html
@@ -31,6 +31,7 @@
     <script src="specs/annotation-list.spec.js"></script>
     <script src="specs/parse-html.spec.js"></script>
     <script src="specs/integration.spec.js" async></script>
+    <script src="specs/monaco-ops.spec.js" async></script>
 
   </head>
   <body>

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -58,6 +58,7 @@ module.exports = function(config) {
       "../lib/client.js",
       "../lib/editor-client.js",
       "../lib/ace-adapter.js",
+      "../lib/monaco-adapter.js",
       "../lib/constants.js",
       "../lib/entity-manager.js",
       "../lib/entity.js",

--- a/test/specs/monaco-ops.spec.js
+++ b/test/specs/monaco-ops.spec.js
@@ -5,12 +5,13 @@ describe('Monaco Operations Test', function () {
     /** Editor Content */
     var editorContent =
 `module Conway {
+
     export class Cell {
         public row: number;
         public col: number;
         public live: boolean;
-
-        varructor(row: number, col: number, live: boolean) {
+        
+        constructor(row: number, col: number, live: boolean) {
             this.row = row;
             this.col = col;
             this.live = live
@@ -25,18 +26,18 @@ describe('Monaco Operations Test', function () {
         { rangeLength: 0, text: '/* ', rangeOffset: 21, forceMoveMarkers: false }
     ];
 
-    /** Text Operations */
+    /** Expected Text Operations */
     var textOperations = [
         new firepad.TextOperation().retain(21).insert('/* ').retain(281),
         new firepad.TextOperation().retain(302).insert(' */').retain(3)
     ];
 
     it('should convert Monaco Editor changes to Text Operation', function () {
-        var operationFromMonacoChanges = MonacoAdapter.prototype.operationFromMonacoChanges;
+        var operationFromMonacoChange = MonacoAdapter.prototype.operationFromMonacoChange;
 
         let offset = 0;
         operations.reverse().forEach((operation, index) => {
-            var pair = operationFromMonacoChanges.call(null, operation, editorContent, offset);
+            var pair = operationFromMonacoChange.call(null, operation, editorContent, offset);
 
             /** Base Length of First Operation must be Target Length of Second Operation */
             expect(pair[1].targetLength).toEqual(pair[0].baseLength);

--- a/test/specs/monaco-ops.spec.js
+++ b/test/specs/monaco-ops.spec.js
@@ -1,0 +1,55 @@
+/** Monaco Adapter Unit Tests */
+describe('Monaco Operations Test', function () {
+    var MonacoAdapter = firepad.MonacoAdapter;
+
+    /** Editor Content */
+    var editorContent =
+`module Conway {
+    export class Cell {
+        public row: number;
+        public col: number;
+        public live: boolean;
+
+        varructor(row: number, col: number, live: boolean) {
+            this.row = row;
+            this.col = col;
+            this.live = live
+        }
+    }
+}
+`;
+
+    /** Editor Changes */
+    var operations = [
+        { rangeLength: 0, text: ' */', rangeOffset: 299, forceMoveMarkers: false },
+        { rangeLength: 0, text: '/* ', rangeOffset: 21, forceMoveMarkers: false }
+    ];
+
+    /** Text Operations */
+    var textOperations = [
+        new firepad.TextOperation().retain(21).insert('/* ').retain(281),
+        new firepad.TextOperation().retain(302).insert(' */').retain(3)
+    ];
+
+    it('should convert Monaco Editor changes to Text Operation', function () {
+        var operationFromMonacoChanges = MonacoAdapter.prototype.operationFromMonacoChanges;
+
+        let offset = 0;
+        operations.reverse().forEach((operation, index) => {
+            var pair = operationFromMonacoChanges.call(null, operation, editorContent, offset);
+
+            /** Base Length of First Operation must be Target Length of Second Operation */
+            expect(pair[1].targetLength).toEqual(pair[0].baseLength);
+
+            /** Base Length of Second Operation must be Target Length of First Operation */
+            expect(pair[0].targetLength).toEqual(pair[1].baseLength);
+
+            /** Correct Operations Returned */
+            expect(pair[0]).toEqual(textOperations[index]);
+
+            /** Update Offset */
+            offset += pair[0].targetLength - pair[0].baseLength;
+        });
+    });
+});
+


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

-->


### Description

Fixes bugs in the Monaco adapter.

(1) Selecting multiple lines and pressing "tab" causes collaborators to merge changes incorrectly.
(2) Selecting multiple lines and commenting them out causes collaborators to merge changes incorrectly.

Both changes are related to the handling of batched operations.

This PR is a minimized version of #325 that omits changes in the overall design of the file. Relies on `monacoModel.getPositionAt` instead of `posFromIndex` and `indexFromPos`.

### Code sample

N/A

### CLA

jbchavez19 signed one for our organization for a previous PR.