### PR TITLE
Fix a incorrect global variable as a local variable

### DIFF
--- a/lib/headless.js
+++ b/lib/headless.js
@@ -56,7 +56,7 @@ firepad.Headless = (function() {
       var text = doc.apply('');
 
       // Strip out any special characters from Rich Text formatting
-      for (key in firepad.sentinelConstants) {
+      for (var key in firepad.sentinelConstants) {
         text = text.replace(new RegExp(firepad.sentinelConstants[key], 'g'), '');
       }
       callback(text);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

I think the 'key' variable is an unexpected global variable.
It would be better to declare it with 'var'.

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->

N/A

