### PR TITLE
Fix failing test for 'defaultText'

### DIFF
--- a/test/specs/integration.spec.js
+++ b/test/specs/integration.spec.js
@@ -137,15 +137,20 @@ describe('Integration tests', function() {
     firepad.on('ready', function() {
       expect(firepad.getText()).toEqual(text);
       firepad.setText(text2);
+      var waitForSync = new Promise(function(resolve) {
+        firepad.on('synced', function(isSync) { if (isSync) resolve(); });
+      });
       var firepad2 = new Firepad(ref, cm2, { defaultText: text});
       firepad2.on('ready', function() {
-        if (firepad2.getText() == text2) {
-          done();
-        } else if (firepad2.getText() == text) {
-          done(new Error('Default text won over edited text'));
-        } else {
-          done(new Error('Second Firepad got neither default nor edited text: ' + JSON.stringify(firepad2.getText())));
-        }
+        waitForSync.then(function() {
+          if (firepad2.getText() == text2) {
+            done();
+          } else if (firepad2.getText() == text) {
+            done(new Error('Default text won over edited text'));
+          } else {
+            done(new Error('Second Firepad got neither default nor edited text: ' + JSON.stringify(firepad2.getText())));
+          }
+        });
       });
     });
   });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

Test should wait for first Firepad to sync. Otherwise the second Firepad still sees an empty ref, and (correctly) initializes with default.

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->
