### PR TITLE
Fix failing test for 'defaultText'

### DIFF
--- a/test/specs/integration.spec.js
+++ b/test/specs/integration.spec.js
@@ -140,9 +140,9 @@ describe('Integration tests', function() {
       var waitForSync = new Promise(function(resolve) {
         firepad.on('synced', function(isSync) { if (isSync) resolve(); });
       });
-      var firepad2 = new Firepad(ref, cm2, { defaultText: text});
-      firepad2.on('ready', function() {
-        waitForSync.then(function() {
+      waitForSync.then(function() {
+        var firepad2 = new Firepad(ref, cm2, { defaultText: text});
+        firepad2.on('ready', function() {
           if (firepad2.getText() == text2) {
             done();
           } else if (firepad2.getText() == text) {


### PR DESCRIPTION
This is based on https://github.com/FirebaseExtended/firepad/pull/339 but I have tweaked the ordering so we wait for the first firepad to sync before initializing the 2nd one at all, since the test is meant to verify that when the 2nd one does initialize, it does not use the default text.