### PR TITLE
Incorrect monaco check

### DIFF
--- a/lib/monaco-adapter.js
+++ b/lib/monaco-adapter.js
@@ -60,7 +60,7 @@ var MonacoAdapter = function () {
   function MonacoAdapter(monacoInstance) {
     /** House Keeping */
     if (monacoInstance !== null && typeof global !== 'undefined' && global.monaco
-      && !monacoInstance instanceof global.monaco) {
+      && !monacoInstance instanceof global.monaco.constructor) {
 
       throw new Error('MonacoAdapter: Incorrect Parameter Recieved in constructor, '
         + 'expected valid Monaco Instance');


### PR DESCRIPTION
### Description

Received an error when trying to use monaco:
`TypeError: Right-hand side of 'instanceof' is not callable`

That's because global.monaco is not a class. I'm not sure how this worked for anyone else.

This check seems to be already done in fireapad.js anyway, and it's doing the check correctly against global.monaco.constructor.
https://github.com/FirebaseExtended/firepad/blob/master/lib/firepad.js#L43
