### PR TITLE
Immediately stop handling revision and callbacks

### DIFF
--- a/lib/firebase-adapter.js
+++ b/lib/firebase-adapter.js
@@ -65,16 +65,15 @@ firepad.FirebaseAdapter = (function (global) {
 
   FirebaseAdapter.prototype.dispose = function() {
     var self = this;
+    this.removeFirebaseCallbacks_();
+    this.handleInitialRevisions_ = () => {};
 
     if (!this.ready_) {
-      // TODO: this completes loading the text even though we're no longer interested in it.
       this.on('ready', function() {
-	self.dispose();
+	      self.dispose();
       });
       return;
     }
-
-    this.removeFirebaseCallbacks_();
 
     if (this.userRef_) {
       this.userRef_.child('cursor').remove();

--- a/test/specs/integration.spec.js
+++ b/test/specs/integration.spec.js
@@ -325,7 +325,7 @@ describe('Integration tests', function() {
     expect(function() {
       var firepad = new Firepad(ref1, cm, { defaultText: 'Default Content'});
       firepad.dispose()
-      // Wait some time for the callbacks to get called, throwing the error
+      // Wait some time for the callbacks to get called
       setTimeout(done, 1)
     }).not.toThrow();
   })
@@ -347,9 +347,7 @@ describe('Integration tests', function() {
           firepad1.dispose();
           cm.setValue('');
 
-          // Create a new Firepad, using the same ref which we added text
-          // This  will start to initialize the Firepad
-          // dispose of this Firepad
+          // Create a new Firepad, using the same ref which we added text to, then dispose it
           var firepad2 = new Firepad(ref1, cm);
           firepad2.dispose()
           firepad2.on('ready', () => {
@@ -357,9 +355,8 @@ describe('Integration tests', function() {
           })
           cm.setValue('');
     
-          // Then we create a new instance of Firepad, passing in a different ref
-          // Without the changes in the PR the text from ref1 will be inserted into code mirror
-          // Comment my changes out and you will see this test fail
+          // Create a new Firepad instance with a different ref
+          // Should not contain text from previously disposed firepad
           var firepad3 = new Firepad(ref2, cm);
           firepad3.on('ready', function(synced) {
             expect(cm.getValue()).toEqual('');


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

Bug Fix.

Firepad waits until it is ready to dispose. This results in Firepad throwing an error, and updating  the code editor with content before destroying.

This fixes that behavior by removing the callbacks from the destroyed instance, and making the function which updates the code editor a no-op before the instance is. in a ready state.

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
