### PR TITLE
Fix incompatibility issue with monaco-editor

### DIFF
--- a/lib/monaco-adapter.js
+++ b/lib/monaco-adapter.js
@@ -60,7 +60,7 @@ var MonacoAdapter = function () {
   function MonacoAdapter(monacoInstance) {
     /** House Keeping */
     if (monacoInstance !== null && typeof global !== 'undefined' && global.monaco
-      && !monacoInstance instanceof global.monaco) {
+      && !Object.values(global.monaco.editor.EditorType).includes(monacoInstance.getEditorType())) {
 
       throw new Error('MonacoAdapter: Incorrect Parameter Recieved in constructor, '
         + 'expected valid Monaco Instance');

--- a/lib/monaco-adapter.js
+++ b/lib/monaco-adapter.js
@@ -59,9 +59,9 @@ var MonacoAdapter = function () {
    */
   function MonacoAdapter(monacoInstance) {
     /** House Keeping */
-    if (monacoInstance !== null && typeof global !== 'undefined' && global.monaco
-      && !Object.values(global.monaco.editor.EditorType).includes(monacoInstance.getEditorType())) {
 
+    // Make sure this looks like a valid monaco instance.
+    if (monacoInstance !== null && typeof monacoInstance.getModel === 'function') {
       throw new Error('MonacoAdapter: Incorrect Parameter Recieved in constructor, '
         + 'expected valid Monaco Instance');
     }


### PR DESCRIPTION
 Currently, we are getting the below error with the latest versions of monaco-editor and firebase:


    typeError: Right-hand side of 'instanceof' is not callable
    new t
    node_modules/firepad/dist/firepad.min.js:1345
    1342 | },
    1343 | o = function () {
    1344 | function t(t) {

The issue has also been reported by another user here: https://github.com/FirebaseExtended/firepad/commit/e39b4c147d6f41a246cb56232a0d6fc33833fd59