### PR TITLE
Don't clear CodeMirror inline styles on setText

### DIFF
--- a/lib/firepad.js
+++ b/lib/firepad.js
@@ -215,10 +215,10 @@ firepad.Firepad = (function(global) {
       return this.ace_.getSession().getDocument().setValue(textPieces);
     } else {
       // HACK: Hide CodeMirror during setText to prevent lots of extra renders.
-      this.codeMirror_.getWrapperElement().setAttribute('style', 'display: none');
+      this.codeMirror_.getWrapperElement().style.display = "none";
       this.codeMirror_.setValue("");
       this.insertText(0, textPieces);
-      this.codeMirror_.getWrapperElement().setAttribute('style', '');
+      this.codeMirror_.getWrapperElement().style.display = "";
       this.codeMirror_.refresh();
     }
     this.editorAdapter_.setCursor({position: 0, selectionEnd: 0});


### PR DESCRIPTION
### Description

Bug fix: `Firepad.prototype.setText` would overwrite the inline styles of the codemirror wrapper element by calling `setAttribute('style', 'display: none')` instead of `style.display = "none"`.

### Code sample

N/A
